### PR TITLE
Use the samba-provided CHECK_CFG method in configuration tests

### DIFF
--- a/lib/util/wscript_configure
+++ b/lib/util/wscript_configure
@@ -110,19 +110,19 @@ conf.SET_TARGET_TYPE('systemd-journal', 'EMPTY')
 conf.SET_TARGET_TYPE('systemd', 'EMPTY')
 
 if Options.options.enable_systemd != False:
-    conf.check_cfg(package='libsystemd-daemon', args='--cflags --libs',
+    conf.CHECK_CFG(package='libsystemd-daemon', args='--cflags --libs',
                    msg='Checking for libsystemd-daemon')
     if not conf.CHECK_LIB('systemd-daemon', shlib=True):
         conf.CHECK_LIB('systemd', shlib=True)
 
 if Options.options.enable_systemd != False:
-    conf.check_cfg(package='libsystemd-journal', args='--cflags --libs',
+    conf.CHECK_CFG(package='libsystemd-journal', args='--cflags --libs',
                    msg='Checking for libsystemd-journal')
     if not conf.CHECK_LIB('systemd-journal', shlib=True):
         conf.CHECK_LIB('systemd', shlib=True)
 
 if Options.options.enable_lttng != False:
-    conf.check_cfg(package='lttng-ust', args='--cflags --libs',
+    conf.CHECK_CFG(package='lttng-ust', args='--cflags --libs',
                    msg='Checking for lttng-ust', uselib_store="LTTNG-UST")
     conf.CHECK_HEADERS('lttng/tracef.h', lib='lttng-st')
     conf.CHECK_LIB('lttng-ust', shlib=True)

--- a/source3/wscript
+++ b/source3/wscript
@@ -1582,7 +1582,7 @@ main() {
         versions = ['1.0', '0.16', '0.14']
         for version in versions:
             testlib = 'tracker-sparql-' + version
-            if conf.check_cfg(package=testlib,
+            if conf.CHECK_CFG(package=testlib,
                               args='--cflags --libs',
                               mandatory=False):
                 conf.SET_TARGET_TYPE(testlib, 'SYSLIB')


### PR DESCRIPTION
This is for forward compatibility with waf 1.8. All other tests
use CHECK_CFG, but check_cfg was re-introduced for some reason.