### PR TITLE
Client timeout

### DIFF
--- a/source3/include/local.h
+++ b/source3/include/local.h
@@ -122,7 +122,7 @@
 /* shall we support browse requests via a FIFO to nmbd? */
 #define ENABLE_FIFO 1
 
-/* how long (in miliseconds) to wait for a socket connect to happen */
+/* how long (in milliseconds) to wait for a socket connect to happen */
 #define LONG_CONNECT_TIMEOUT 30000
 #define SHORT_CONNECT_TIMEOUT 5000
 

--- a/source3/include/local.h
+++ b/source3/include/local.h
@@ -122,7 +122,8 @@
 /* shall we support browse requests via a FIFO to nmbd? */
 #define ENABLE_FIFO 1
 
-/* how long (in milliseconds) to wait for a socket connect to happen */
+/* How long (in milliseconds) to wait for a socket connect to happen. 
+   Also defined in source4/lib/socket/socket.h */
 #define LONG_CONNECT_TIMEOUT 30000
 #define SHORT_CONNECT_TIMEOUT 5000
 

--- a/source4/lib/socket/socket.h
+++ b/source4/lib/socket/socket.h
@@ -20,6 +20,9 @@
 #ifndef _SAMBA_SOCKET_H
 #define _SAMBA_SOCKET_H
 
+/* See source3/include/local.h for source3 socket timeout definitions. */
+#define LONG_CONNECT_TIMEOUT 30000
+
 struct tevent_context;
 struct tevent_fd;
 struct socket_context;

--- a/source4/libcli/raw/clisocket.c
+++ b/source4/libcli/raw/clisocket.c
@@ -298,7 +298,7 @@ static struct tevent_req *smbcli_sock_establish_send(TALLOC_CTX *mem_ctx,
 	struct sock_connect_state *state =
 		talloc_get_type_abort(private_data,
 		struct sock_connect_state);
-	uint32_t timeout_msec = 15 * 1000;
+	uint32_t timeout_msec = LONG_CONNECT_TIMEOUT;
 
 	return smbcli_transport_connect_send(state,
 					     ev,


### PR DESCRIPTION
Fix client socket timeout to be consistent between source3 and source4.  This changes source4's socket timeout from 15 seconds to the old source3 value of 30 seconds.  

Could I get two Team members to sign off on this, please?