### PR TITLE
lib/param: handle (ignore) substitution variable in smb.conf

### DIFF
--- a/lib/param/loadparm.c
+++ b/lib/param/loadparm.c
@@ -1106,8 +1106,10 @@ bool handle_include(struct loadparm_context *lp_ctx, struct loadparm_service *se
 	if (file_exist(fname))
 		return pm_process(fname, do_section, lpcfg_do_parameter, lp_ctx);
 
-	/* If the file doesn't exist, we check that it isn't due to variable
-	   substitution */
+	/*
+	 * If the file doesn't exist, we check that it isn't due to variable
+	 * substitution
+	 */
 	substitution_variable_substring = strchr(fname, '%');
 
 	if (substitution_variable_substring != NULL) {

--- a/lib/param/loadparm.c
+++ b/lib/param/loadparm.c
@@ -1090,8 +1090,6 @@ bool handle_include(struct loadparm_context *lp_ctx, struct loadparm_service *se
 			   const char *pszParmValue, char **ptr)
 {
 	char *fname;
-	char *substitution_variable_substring;
-	char next_char;
 
 	if (lp_ctx->s3_fns) {
 		return lp_ctx->s3_fns->lp_include(lp_ctx, service, pszParmValue, ptr);
@@ -1103,36 +1101,8 @@ bool handle_include(struct loadparm_context *lp_ctx, struct loadparm_service *se
 
 	lpcfg_string_set(lp_ctx, ptr, fname);
 
-	if (file_exist(fname)) {
+	if (file_exist(fname))
 		return pm_process(fname, do_section, lpcfg_do_parameter, lp_ctx);
-	} else {
-		char *substitution_variable_substring;
-		substitution_variable_substring = strchr(fname, '%');
-
-		if (substitution_variable_substring) {
-			char next_char = substitution_variable_substring[1];
-			if ((next_char >= 'a' && next_char <= 'z')
-			    || (next_char >= 'A' && next_char <= 'Z')) {
-				DEBUG(2, ("Tried to load %s but variable in "
-					  "filename, ignoring file.\n", fname));
-				return true;
-			}
-		}
-	}
-
-	/* If the file doesn't exist, we check that it isn't due to variable
-	   substitution */
-	substitution_variable_substring = strchr(fname, '%');
-
-	if (substitution_variable_substring != NULL) {
-		next_char = substitution_variable_substring[1];
-		if ((next_char >= 'a' && next_char <= 'z')
-		    || (next_char >= 'A' && next_char <= 'Z')) {
-			DEBUG(2, ("Tried to load %s but variable substitution in "
-				 "filename, ignoring file.\n", fname));
-			return true;
-		}
-	}
 
 	DEBUG(2, ("Can't find include file %s\n", fname));
 

--- a/source4/lib/messaging/messaging.c
+++ b/source4/lib/messaging/messaging.c
@@ -323,7 +323,7 @@ struct imessaging_context *imessaging_init(TALLOC_CTX *mem_ctx,
 
 	/* create the messaging directory if needed */
 
-	msg->sock_dir = lpcfg_private_path(msg, lp_ctx, "sock");
+	msg->sock_dir = lpcfg_private_path(msg, lp_ctx, "msg.sock");
 	if (msg->sock_dir == NULL) {
 		goto fail;
 	}
@@ -332,7 +332,7 @@ struct imessaging_context *imessaging_init(TALLOC_CTX *mem_ctx,
 		goto fail;
 	}
 
-	msg->lock_dir = lpcfg_lock_path(msg, lp_ctx, "msg");
+	msg->lock_dir = lpcfg_lock_path(msg, lp_ctx, "msg.lock");
 	if (msg->lock_dir == NULL) {
 		goto fail;
 	}


### PR DESCRIPTION
Signed-off-by: Quentin Gibeaux <qgibeaux@iris-tech.fr>

Pull request of fix in regards to https://bugzilla.samba.org/show_bug.cgi?id=10722

Summary  (see bugtrack for details) : 
I've encountered an annoying bug with samba-tool, some exceptions aren't caught causing the tool to crash if it finds something it doesn't like in the smb.conf.
I have a specific line in my conf : "include = /etc/samba/%U.smb.conf ", it's useful for applying specific samba configuration for a specific user, it works on the samba side, but when samba-tool reads the conf, it crashs :

root@server:~/samba# samba-tool user list
Processing section "[global]"
(…)
Can't find include file /etc/samba/%U.smb.conf
params.c:pm_process() - Failed. Error returned from params.c:parse().
pm_process() returned No
ERROR(runtime): uncaught exception - Unable to load default file
File "/usr/lib/python2.7/dist-packages/samba/netcmd/__init__.py", line 175, in _run
return self.run(*args, **kwargs)
File "/usr/lib/python2.7/dist-packages/samba/netcmd/user.py", line 261, in run
lp = sambaopts.get_loadparm()
File "/usr/lib/python2.7/dist-packages/samba/getopt.py", line 92, in get_loadparm
self._lp.load_default()

In fact it crashes for any include with any variable substitution (%U, %g, %a…).