### PR TITLE
build:wafsamba: Set the default installation prefix for Waf 1.8

### DIFF
--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -26,7 +26,7 @@ else:
 version = samba_version.samba_version_file('%s/VERSION' % vdir, vdir, env)
 VERSION = version.STRING.replace('-', '.')
 
-Options.default_prefix = '/usr/local'
+default_prefix = Options.default_prefix = '/usr/local'
 
 samba_dist.DIST_DIRS('''ctdb:. lib/replace:lib/replace lib/talloc:lib/talloc
                         lib/tevent:lib/tevent lib/tdb:lib/tdb

--- a/source3/wscript
+++ b/source3/wscript
@@ -11,7 +11,7 @@ import build.charset
 import samba_utils, samba_version
 import samba3
 
-Options.default_prefix = '/usr/local/samba'
+default_prefix = Options.default_prefix = '/usr/local/samba'
 
 def set_options(opt):
 

--- a/wscript
+++ b/wscript
@@ -15,7 +15,7 @@ samba_dist.DIST_DIRS('.')
 samba_dist.DIST_BLACKLIST('.gitignore .bzrignore source4/selftest/provisions')
 
 # install in /usr/local/samba by default
-Options.default_prefix = '/usr/local/samba'
+default_prefix = Options.default_prefix = '/usr/local/samba'
 
 # This callback optionally takes a list of paths as arguments:
 # --with-system_mitkrb5 /path/to/krb5 /another/path


### PR DESCRIPTION
These changes enable the default installation prefix settings to
take effect in both Waf 1.5 and 1.8 with no additional code changes.