### PR TITLE
build:wafsamba: Enable feature-compatible declaration for Waf 1.8

### DIFF
--- a/buildtools/wafsamba/gccdeps.py
+++ b/buildtools/wafsamba/gccdeps.py
@@ -14,7 +14,7 @@ lock = threading.Lock()
 
 preprocessor_flag = '-MD'
 
-@feature('cc')
+@feature('c', 'cc')
 @before('apply_core')
 def add_mmd_cc(self):
     if self.env.get_flat('CCFLAGS').find(preprocessor_flag) < 0:

--- a/buildtools/wafsamba/samba_autoconf.py
+++ b/buildtools/wafsamba/samba_autoconf.py
@@ -569,7 +569,7 @@ int foo()
 
         (ccflags, ldflags, cpppath) = library_flags(conf, lib)
         if shlib:
-            res = conf.check(features='cc cshlib', fragment=fragment, lib=lib, uselib_store=lib, ccflags=ccflags, ldflags=ldflags, uselib=lib.upper())
+            res = conf.check(features='c cshlib', fragment=fragment, lib=lib, uselib_store=lib, ccflags=ccflags, ldflags=ldflags, uselib=lib.upper())
         else:
             res = conf.check(lib=lib, uselib_store=lib, ccflags=ccflags, ldflags=ldflags, uselib=lib.upper())
 

--- a/buildtools/wafsamba/samba_conftests.py
+++ b/buildtools/wafsamba/samba_conftests.py
@@ -197,7 +197,7 @@ int foo(int v) {
     return v * 2;
 }
 '''
-    return conf.check(features='cc cshlib',vnum="1",fragment=snip,msg=msg)
+    return conf.check(features='c cshlib',vnum="1",fragment=snip,msg=msg)
 
 @conf
 def CHECK_NEED_LC(conf, msg):
@@ -227,7 +227,7 @@ def CHECK_NEED_LC(conf, msg):
 
     bld.rescan(bld.srcnode)
 
-    bld(features='cc cshlib',
+    bld(features='c cshlib',
         source='liblctest/liblc1.c',
         ldflags=conf.env['EXTRA_LDFLAGS'],
         target='liblc',
@@ -262,7 +262,7 @@ int foo(int v) {
     ldb_module = PyImport_ImportModule("ldb");
     return v * 2;
 }'''
-    return conf.check(features='cc cshlib',uselib='PYEMBED',fragment=snip,msg=msg)
+    return conf.check(features='c cshlib',uselib='PYEMBED',fragment=snip,msg=msg)
 
 # this one is quite complex, and should probably be broken up
 # into several parts. I'd quite like to create a set of CHECK_COMPOUND()
@@ -306,13 +306,13 @@ def CHECK_LIBRARY_SUPPORT(conf, rpath=False, version_script=False, msg=None):
         ldflags.append("-Wl,--version-script=%s/vscript" % bld.path.abspath())
         Utils.writef(os.path.join(dir,'vscript'), 'TEST_1.0A2 { global: *; };\n')
 
-    bld(features='cc cshlib',
+    bld(features='c cshlib',
         source='libdir/lib1.c',
         target='libdir/lib1',
         ldflags=ldflags,
         name='lib1')
 
-    o = bld(features='cc cprogram',
+    o = bld(features='c cprogram',
             source='main.c',
             target='prog1',
             uselib_local='lib1')

--- a/buildtools/wafsamba/samba_optimisation.py
+++ b/buildtools/wafsamba/samba_optimisation.py
@@ -11,7 +11,7 @@ import Build, Utils, Node
 from TaskGen import feature, after, before
 import preproc
 
-@feature('cc', 'cxx')
+@feature('c', 'cc', 'cxx')
 @after('apply_type_vars', 'apply_lib_vars', 'apply_core')
 def apply_incpaths(self):
     lst = []
@@ -59,7 +59,7 @@ def apply_incpaths(self):
         if node:
             self.env.append_value('INC_PATHS', node)
 
-@feature('cc')
+@feature('c', 'cc')
 @after('apply_incpaths')
 def apply_obj_vars_cc(self):
     """after apply_incpaths for INC_PATHS"""
@@ -187,7 +187,7 @@ def shared_ancestors(self):
         return ret
 TaskGen.task_gen.shared_ancestors = shared_ancestors
 
-@feature('cc', 'cxx')
+@feature('c', 'cc', 'cxx')
 @after('apply_link', 'init_cc', 'init_cxx', 'apply_core')
 def apply_lib_vars(self):
     """after apply_link because of 'link_task'

--- a/buildtools/wafsamba/samba_utils.py
+++ b/buildtools/wafsamba/samba_utils.py
@@ -164,7 +164,7 @@ def ADD_COMMAND(opt, name, function):
 Options.Handler.ADD_COMMAND = ADD_COMMAND
 
 
-@feature('cc', 'cshlib', 'cprogram')
+@feature('c', 'cc', 'cshlib', 'cprogram')
 @before('apply_core','exec_rule')
 def process_depends_on(self):
     '''The new depends_on attribute for build rules

--- a/buildtools/wafsamba/wafsamba.py
+++ b/buildtools/wafsamba/wafsamba.py
@@ -243,7 +243,7 @@ def SAMBA_LIBRARY(bld, libname, source,
     if bld.env['ENABLE_RELRO'] is True:
         ldflags.extend(TO_LIST('-Wl,-z,relro,-z,now'))
 
-    features = 'cc cshlib symlink_lib install_lib'
+    features = 'c cshlib symlink_lib install_lib'
     if pyext:
         features += ' pyext'
     if pyembed:
@@ -354,7 +354,7 @@ def SAMBA_BINARY(bld, binname, source,
     if not SET_TARGET_TYPE(bld, binname, 'BINARY'):
         return
 
-    features = 'cc cprogram symlink_bin install_bin'
+    features = 'c cprogram symlink_bin install_bin'
     if pyembed:
         features += ' pyembed'
 
@@ -578,7 +578,7 @@ def SAMBA_SUBSYSTEM(bld, modname, source,
 
     bld.SET_BUILD_GROUP(group)
 
-    features = 'cc'
+    features = 'c'
     if pyext:
         features += ' pyext'
     if pyembed:

--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -241,7 +241,7 @@ def configure(conf):
         cc.run = Task.compile_fun_noshell('cc', '${CC} ${CCFLAGS} ${CPPFLAGS} ${_CCINCFLAGS} ${_CCDEFFLAGS} ${CC_SRC_F}${SRC} ${CC_TGT_F}${TGT[0].abspath(env)}')[0]
         try:
             try:
-                conf.check(features='cc testd', fragment='int main() {return 0;}\n', ccflags=['-MD'], mandatory=True, msg='Check for -MD')
+                conf.check(features='c testd', fragment='int main() {return 0;}\n', ccflags=['-MD'], mandatory=True, msg='Check for -MD')
             except:
                 pass
             else:

--- a/source4/heimdal_build/wscript_build
+++ b/source4/heimdal_build/wscript_build
@@ -69,7 +69,7 @@ def HEIMDAL_ASN1(name, source,
 
     t = bld(rule=asn1_rule,
             ext_out = '.x',
-            before = 'cc',
+            before = 'c',
             update_outputs = True,
             shell = True,
             source = source,
@@ -123,7 +123,7 @@ def HEIMDAL_ASN1(name, source,
     includes = to_list(includes)
     includes.append(os.path.dirname(out_files[0]))
 
-    t = bld(features       = 'cc',
+    t = bld(features       = 'c',
             source         = cfile,
             target         = name,
             samba_cflags   = CURRENT_CFLAGS(bld, name, ''),
@@ -241,7 +241,7 @@ def HEIMDAL_LIBRARY(libname, source, deps, vnum, version_script, includes=''):
         bundled_name = libname
     version = "%s_%s" % (Utils.g_module.APPNAME, Utils.g_module.VERSION)
 
-    features = 'cc cshlib symlink_lib install_lib'
+    features = 'c cshlib symlink_lib install_lib'
 
     bld.set_group('main')
     t = bld(
@@ -277,7 +277,7 @@ def HEIMDAL_SUBSYSTEM(modname, source,
     bld.set_group(group)
 
     return bld(
-        features       = 'cc',
+        features       = 'c',
         source         = source,
         target         = modname,
         samba_cflags   = CURRENT_CFLAGS(bld, modname, cflags, allow_warnings=True),
@@ -306,7 +306,7 @@ def HEIMDAL_BINARY(binname, source,
     if not SET_TARGET_TYPE(bld, binname, 'BINARY'):
         return
 
-    features = 'cc cprogram symlink_bin install_bin'
+    features = 'c cprogram symlink_bin install_bin'
 
     obj_target = binname + '.objlist'
 


### PR DESCRIPTION
In Waf 1.8 the declaration is features='c', not features='cc'. These changes
prepare the replacement of Waf 1.5 by Waf 1.8 for Samba.

Signed-off-by: Thomas Nagy <tnagy@waf.io>
Reviewed-by: ?