### PR TITLE
Add --set-nt-hash parameter to pdbedit to update user password from nt-hash hexstring.

### DIFF
--- a/docs-xml/manpages/pdbedit.8.xml
+++ b/docs-xml/manpages/pdbedit.8.xml
@@ -43,6 +43,7 @@
 		<arg choice="opt">-r</arg>
 		<arg choice="opt">-s configfile</arg>
 		<arg choice="opt">-S script</arg>
+		<arg choice="opt">--set-nt-hash</arg>
 		<arg choice="opt">-t</arg>
 		<arg choice="opt">--time-format</arg>
 		<arg choice="opt">-u username</arg>
@@ -99,7 +100,8 @@ samba:45:Test User
 		<term>-v|--verbose</term>
 		<listitem><para>This option enables the verbose listing format.
 		It causes pdbedit to list the users in the database, printing
-		out the account fields in a descriptive format.</para>
+		out the account fields in a descriptive format. Used together
+		with -w also shows passwords hashes.</para>
 
 		<para>Example: <command>pdbedit -L -v</command></para>
 		<para><programlisting>
@@ -134,7 +136,9 @@ Profile Path:   \\BERSERKER\profile
 		out the account fields in a format compatible with the
 		<filename>smbpasswd</filename> file format. (see the
 		<citerefentry><refentrytitle>smbpasswd</refentrytitle>
-		<manvolnum>5</manvolnum></citerefentry> for details)</para>
+		<manvolnum>5</manvolnum></citerefentry> for details).
+		Instead used together with (-v) displays the passwords
+		hashes in verbose output.</para>
 
 		<para>Example: <command>pdbedit -L -w</command></para>
 		<programlisting>
@@ -204,6 +208,18 @@ samba:45:0F2B255F7B67A7A9AAD3B435B51404EE:
 		</varlistentry>
 		
 		
+		<varlistentry>
+		<term>--set-nt-hash</term>
+		<listitem><para>This option can be used while modifying
+		a user account. It will set the user's password using
+		the nt-hash value given as hexadecimal string.
+		Useful to synchronize passwords.</para>
+       
+		<para>Example: <literal>--set-nt-hash 8846F7EAEE8FB117AD06BDD830B7586C</literal>
+		</para>
+		</listitem>
+		</varlistentry>
+
 		<varlistentry>
 		<term>-p|--profile profile</term>
 		<listitem><para>This option can be used while adding or

--- a/source3/include/passdb.h
+++ b/source3/include/passdb.h
@@ -811,6 +811,7 @@ bool pdb_set_nt_passwd(struct samu *sampass, const uint8_t pwd[NT_HASH_LEN], enu
 bool pdb_set_lanman_passwd(struct samu *sampass, const uint8_t pwd[LM_HASH_LEN], enum pdb_value_state flag);
 bool pdb_set_pw_history(struct samu *sampass, const uint8_t *pwd, uint32_t historyLen, enum pdb_value_state flag);
 bool pdb_set_plaintext_pw_only(struct samu *sampass, const char *password, enum pdb_value_state flag);
+bool pdb_update_history(struct samu *sampass, const uint8_t new_nt[NT_HASH_LEN]);
 bool pdb_set_bad_password_count(struct samu *sampass, uint16_t bad_password_count, enum pdb_value_state flag);
 bool pdb_set_logon_count(struct samu *sampass, uint16_t logon_count, enum pdb_value_state flag);
 bool pdb_set_country_code(struct samu *sampass, uint16_t country_code,


### PR DESCRIPTION
I modify pdbedit to   set password from  nt-hash to an existing user.This 
is useful to take in sync password  (for example from OpenLdap) .It is 
also updated password-history.
pbedit  with -vw (verbose & smbpasswd-style )  shows the password hashes 
in the verbose output.

Signed-off-by: Alberto Maria Fiaschi <alberto.fiaschi@estar.toscana.it>



