### PR TITLE
build: Build *_wrapper without -DNDEBUG for in-tree use

### DIFF
--- a/lib/nss_wrapper/wscript
+++ b/lib/nss_wrapper/wscript
@@ -102,7 +102,6 @@ def build(bld):
         # breaks preloading!
         bld.SAMBA_LIBRARY('nss_wrapper',
                           source='nss_wrapper.c',
-                          cflags='-DNDEBUG',
                           deps='dl',
                           install=False,
                           realname='libnss-wrapper.so')

--- a/lib/resolv_wrapper/wscript
+++ b/lib/resolv_wrapper/wscript
@@ -92,7 +92,6 @@ def build(bld):
         # breaks preloading!
         bld.SAMBA_LIBRARY('resolv_wrapper',
                           source='resolv_wrapper.c',
-                          cflags='-DNDEBUG',
                           deps='dl resolv',
                           install=False,
                           realname='libresolv-wrapper.so')

--- a/lib/socket_wrapper/wscript
+++ b/lib/socket_wrapper/wscript
@@ -107,7 +107,6 @@ def build(bld):
         # breaks preloading!
         bld.SAMBA_LIBRARY('socket_wrapper',
                           source='socket_wrapper.c',
-                          cflags='-DNDEBUG',
                           deps='dl',
                           install=False,
                           realname='libsocket-wrapper.so')

--- a/lib/uid_wrapper/wscript
+++ b/lib/uid_wrapper/wscript
@@ -125,7 +125,6 @@ def build(bld):
         # breaks preloading!
         bld.SAMBA_LIBRARY('uid_wrapper',
                           source='uid_wrapper.c',
-                          cflags='-DNDEBUG',
                           deps='dl',
                           install=False,
                           realname='libuid-wrapper.so')


### PR DESCRIPTION
These binaires are not installed, so are only used in make test,
and there we need debug output.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>