### PR TITLE
build:wafsamba: dead code removal in gettext detection

### DIFF
--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -78,9 +78,6 @@ def set_options(opt):
                    help='additional directory to search for libiconv',
                    action='store', dest='iconv_open', default='/usr/local',
                    match = ['Checking for library iconv', 'Checking for iconv_open', 'Checking for header iconv.h'])
-    opt.add_option('--with-gettext',
-                   help='additional directory to search for gettext',
-                   action='store', dest='gettext_location', default='None')
     opt.add_option('--without-gettext',
                    help=("Disable use of gettext"),
                    action="store_true", dest='disable_gettext', default=False)

--- a/lib/replace/wscript
+++ b/lib/replace/wscript
@@ -361,13 +361,6 @@ removeea setea
     # try to find libintl (if --without-gettext is not given)
     conf.env.intl_libs=''
     if not Options.options.disable_gettext:
-        # any extra path given to look at?
-        if not Options.options.gettext_location == 'None':
-           conf.env['CFLAGS'].extend(["-I%s" % Options.options.gettext_location]);
-           conf.env['LDFLAGS'].extend(["-L%s" % Options.options.gettext_location]);
-        else:
-           conf.env['CFLAGS'].extend(["-I/usr/local"]);
-           conf.env['LDFLAGS'].extend(["-L/usr/local"]);
         conf.CHECK_HEADERS('libintl.h')
         conf.CHECK_LIB('intl')
         conf.CHECK_DECLS('dgettext gettext bindtextdomain textdomain bind_textdomain_codeset', headers="libintl.h")
@@ -406,10 +399,6 @@ removeea setea
     if not (conf.env['HAVE_DGETTEXT'] and conf.env['HAVE_DECL_DGETTEXT']):
        conf.undefine('HAVE_DGETTEXT')
        conf.undefine('HAVE_DECL_DGETTEXT')
-
-    # did the user insist on gettext (--with-gettext)?
-    if Options.options.gettext_location != 'None' and (not conf.env['HAVE_GETTEXT'] or not conf.env['HAVE_DGETTEXT']):
-        conf.fatal('library gettext not found at specified location')
 
     conf.CHECK_FUNCS_IN('pthread_create', 'pthread', checklibc=True, headers='pthread.h')
 


### PR DESCRIPTION
Removed the --with-gettext option as it has no effect and the code is broken and misleading. Should such options added in the future, use the samba functions such as ADD_CFLAGS.

Signed-off-by: Thomas Nagy <tnagy@waf.io>
Reviewed-by: <your name here>
Reviewed-by: <your name here>