### PR TITLE
build:wafsamba: removed most import * statements

### DIFF
--- a/buildtools/wafsamba/configure_file.py
+++ b/buildtools/wafsamba/configure_file.py
@@ -1,7 +1,8 @@
 # handle substitution of variables in .in files
 
+import re, os
 import Build, sys, Logs
-from samba_utils import *
+from samba_utils import SUBST_VARS_RECURSIVE
 
 def subst_at_vars(task):
     '''substiture @VAR@ style variables in a file'''

--- a/buildtools/wafsamba/nothreads.py
+++ b/buildtools/wafsamba/nothreads.py
@@ -10,12 +10,11 @@
 
 "Execute the tasks"
 
-import sys, random, time, threading, traceback, os
+import sys, random, threading
 try: from Queue import Queue
 except ImportError: from queue import Queue
-import Build, Utils, Logs, Options
-from Logs import debug, error
-from Constants import *
+import Utils, Options
+from Constants import EXCEPTION, CRASHED, MAXJOBS, ASK_LATER, SKIPPED, SKIP_ME, SUCCESS
 
 GAP = 15
 

--- a/buildtools/wafsamba/pkgconfig.py
+++ b/buildtools/wafsamba/pkgconfig.py
@@ -1,7 +1,8 @@
 # handle substitution of variables in pc files
 
-import Build, sys, Logs
-from samba_utils import *
+import os, re, sys
+import Build, Logs
+from samba_utils import SUBST_VARS_RECURSIVE, TO_LIST
 
 def subst_at_vars(task):
     '''substiture @VAR@ style variables in a file'''

--- a/buildtools/wafsamba/samba_autoconf.py
+++ b/buildtools/wafsamba/samba_autoconf.py
@@ -1,10 +1,10 @@
 # a waf tool to add autoconf-like macros to the configure section
 
-import Build, os, sys, Options, preproc, Logs
-import string
+import os, sys
+import Build, Options, preproc, Logs
 from Configure import conf
-from samba_utils import *
-import samba_cross
+from TaskGen import feature
+from samba_utils import TO_LIST, GET_TARGET_TYPE, SET_TARGET_TYPE, runonce, unique_list, mkdir_p
 
 missing_headers = set()
 

--- a/buildtools/wafsamba/samba_autoproto.py
+++ b/buildtools/wafsamba/samba_autoproto.py
@@ -1,7 +1,8 @@
 # waf build tool for building automatic prototypes from C source
 
+import os
 import Build
-from samba_utils import *
+from samba_utils import SET_TARGET_TYPE, os_path_relpath
 
 def SAMBA_AUTOPROTO(bld, header, source):
     '''rule for samba prototype generation'''

--- a/buildtools/wafsamba/samba_bundled.py
+++ b/buildtools/wafsamba/samba_bundled.py
@@ -1,8 +1,9 @@
 # functions to support bundled libraries
 
+import sys
+import Build, Options, Logs
 from Configure import conf
-import sys, Logs
-from samba_utils import *
+from samba_utils import TO_LIST, runonce
 
 def PRIVATE_NAME(bld, name, private_extension, private_library):
     '''possibly rename a library to include a bundled extension'''

--- a/buildtools/wafsamba/samba_conftests.py
+++ b/buildtools/wafsamba/samba_conftests.py
@@ -1,11 +1,11 @@
 # a set of config tests that use the samba_autoconf functions
 # to test for commonly needed configuration options
 
-import os, shutil, re
-import Build, Configure, Utils
+import os, shutil, re, shlex
+import Build, Configure, Utils, Options, Logs
 from Configure import conf
 import config_c
-from samba_utils import *
+from samba_utils import TO_LIST, ADD_LD_LIBRARY_PATH
 
 
 def add_option(self, *k, **kw):

--- a/buildtools/wafsamba/samba_cross.py
+++ b/buildtools/wafsamba/samba_cross.py
@@ -1,8 +1,8 @@
 # functions for handling cross-compilation
 
-import Utils, Logs, sys, os, Options, re
+import os, sys, re, shlex
+import Utils, Logs, Options
 from Configure import conf
-import shlex
 
 real_Popen = None
 

--- a/buildtools/wafsamba/samba_deps.py
+++ b/buildtools/wafsamba/samba_deps.py
@@ -1,9 +1,14 @@
 # Samba automatic dependency handling and project rules
 
-import Build, os, sys, re, Environment, Logs, time
-from samba_utils import *
-from samba_autoconf import *
+import os, sys, re, time
+
+import Build, Environment, Options, Logs, Utils
+from Logs import debug
+from Configure import conf
+
 from samba_bundled import BUILTIN_LIBRARY
+from samba_utils import LOCAL_CACHE, TO_LIST, get_tgt_list, unique_list, os_path_relpath
+from samba_autoconf import library_flags
 
 @conf
 def ADD_GLOBAL_DEPENDENCY(ctx, dep):

--- a/buildtools/wafsamba/samba_dist.py
+++ b/buildtools/wafsamba/samba_dist.py
@@ -1,8 +1,10 @@
 # customised version of 'waf dist' for Samba tools
 # uses git ls-files to get file lists
 
-import Utils, os, sys, tarfile, stat, Scripting, Logs, Options
-from samba_utils import *
+import os, sys, tarfile
+import Utils, Scripting, Logs, Options
+from Configure import conf
+from samba_utils import os_path_relpath
 
 dist_dirs = None
 dist_files = None

--- a/buildtools/wafsamba/samba_headers.py
+++ b/buildtools/wafsamba/samba_headers.py
@@ -1,7 +1,8 @@
 # specialist handling of header files for Samba
 
-import Build, re, Task, TaskGen, shutil, sys, Logs
-from samba_utils import *
+import os, re, sys, fnmatch
+import Build, Logs, Utils
+from samba_utils import TO_LIST, os_path_relpath
 
 
 def header_install_path(header, header_path):

--- a/buildtools/wafsamba/samba_install.py
+++ b/buildtools/wafsamba/samba_install.py
@@ -3,9 +3,10 @@
 # with all the configure options that affect rpath and shared
 # library use
 
-import Options
+import os
+import Options, Utils
 from TaskGen import feature, before, after
-from samba_utils import *
+from samba_utils import LIB_PATH, MODE_755, install_rpath, build_rpath
 
 @feature('install_bin')
 @after('apply_core')
@@ -224,7 +225,6 @@ def symlink_bin(self):
     if self.target.endswith('.inst'):
         return
 
-    blddir = os.path.dirname(self.bld.srcnode.abspath(self.bld.env))
     if not self.link_task.outputs or not self.link_task.outputs[0]:
         raise Utils.WafError('no outputs found for %s in symlink_bin' % self.name)
     binpath = self.link_task.outputs[0].abspath(self.env)

--- a/buildtools/wafsamba/samba_patterns.py
+++ b/buildtools/wafsamba/samba_patterns.py
@@ -1,8 +1,6 @@
 # a waf tool to add extension based build patterns for Samba
 
-import Task
-from TaskGen import extension
-from samba_utils import *
+import Build
 from wafsamba import samba_version_file
 
 def write_version_header(task):

--- a/buildtools/wafsamba/samba_perl.py
+++ b/buildtools/wafsamba/samba_perl.py
@@ -1,5 +1,4 @@
-import Build
-from samba_utils import *
+import Utils
 from Configure import conf
 
 done = {}

--- a/buildtools/wafsamba/samba_pidl.py
+++ b/buildtools/wafsamba/samba_pidl.py
@@ -1,8 +1,9 @@
 # waf build tool for building IDL files with pidl
 
-from TaskGen import before
-import Build, os, sys, Logs
-from samba_utils import *
+import os
+import Build
+from TaskGen import feature, before
+from samba_utils import SET_TARGET_TYPE, TO_LIST, LOCAL_CACHE
 
 def SAMBA_PIDL(bld, pname, source,
                options='',
@@ -112,7 +113,6 @@ Build.BuildContext.SAMBA_PIDL_LIST = SAMBA_PIDL_LIST
 
 #################################################################
 # the rule for generating the NDR tables
-from TaskGen import feature, before
 @feature('collect')
 @before('exec_rule')
 def collect(self):
@@ -128,7 +128,6 @@ def collect(self):
 
 def SAMBA_PIDL_TABLES(bld, name, target):
     '''generate the pidl NDR tables file'''
-    headers = bld.env.PIDL_HEADERS
     bld.SET_BUILD_GROUP('main')
     t = bld(
             features = 'collect',

--- a/buildtools/wafsamba/samba_python.py
+++ b/buildtools/wafsamba/samba_python.py
@@ -1,9 +1,7 @@
 # waf build tool for building IDL files with pidl
 
-import Build
-from samba_utils import *
-from samba_autoconf import *
-
+import os
+import Build, Logs, Utils
 from Configure import conf
 
 @conf

--- a/buildtools/wafsamba/samba_third_party.py
+++ b/buildtools/wafsamba/samba_third_party.py
@@ -1,8 +1,8 @@
 # functions to support third party libraries
 
+import os
+import Utils, Build
 from Configure import conf
-import sys, Logs, os
-from samba_bundled import *
 
 @conf
 def CHECK_FOR_THIRD_PARTY(conf):

--- a/buildtools/wafsamba/samba_utils.py
+++ b/buildtools/wafsamba/samba_utils.py
@@ -1,11 +1,11 @@
 # a waf tool to add autoconf-like macros to the configure section
 # and for SAMBA_ macros for building libraries, binaries etc
 
-import Build, os, sys, Options, Utils, Task, re, fnmatch, Logs
+import os, sys, re, fnmatch, shlex
+import Build, Options, Utils, Task, Logs
 from TaskGen import feature, before
 from Configure import conf, ConfigurationContext
 from Logs import debug
-import shlex
 
 # TODO: make this a --option
 LIB_PATH="shared"
@@ -140,7 +140,6 @@ def exec_command(self, cmd, **kw):
     '''this overrides the 'waf -v' debug output to be in a nice
     unix like format instead of a python list.
     Thanks to ita on #waf for this'''
-    import Utils, Logs
     _cmd = cmd
     if isinstance(cmd, list):
         _cmd = ' '.join(cmd)

--- a/buildtools/wafsamba/samba_wildcard.py
+++ b/buildtools/wafsamba/samba_wildcard.py
@@ -1,9 +1,9 @@
 # based on playground/evil in the waf svn tree
 
-import os, datetime
-import Scripting, Utils, Options, Logs, Environment, fnmatch
-from Constants import *
-from samba_utils import *
+import os, datetime, fnmatch
+import Scripting, Utils, Options, Logs, Environment
+from Constants import SRCDIR, BLDDIR
+from samba_utils import LOCAL_CACHE, os_path_relpath
 
 def run_task(t, k):
     '''run a single build task'''

--- a/buildtools/wafsamba/symbols.py
+++ b/buildtools/wafsamba/symbols.py
@@ -1,9 +1,10 @@
 # a waf tool to extract symbols from object files or libraries
 # using nm, producing a set of exposed defined/undefined symbols
 
-import Utils, Build, subprocess, Logs, re
-from samba_wildcard import fake_build_environment
-from samba_utils import *
+import os, re, subprocess
+import Utils, Build, Options, Logs
+from Logs import debug
+from samba_utils import TO_LIST, LOCAL_CACHE, get_tgt_list, os_path_relpath
 
 # these are the data structures used in symbols.py:
 #

--- a/buildtools/wafsamba/wafsamba.py
+++ b/buildtools/wafsamba/wafsamba.py
@@ -20,6 +20,7 @@ from samba_perl import *
 from samba_deps import *
 from samba_bundled import *
 from samba_third_party import *
+import samba_cross
 import samba_install
 import samba_conftests
 import samba_abi

--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -2,9 +2,9 @@
 
 # this is a base set of waf rules that everything else pulls in first
 
-import sys, wafsamba, Configure, Logs
-import Options, os, preproc
-from samba_utils import *
+import os, sys
+import wafsamba, Configure, Logs, Options, Utils
+from samba_utils import os_path_relpath
 from optparse import SUPPRESS_HELP
 
 # this forces configure to be re-run if any of the configure

--- a/pidl/wscript
+++ b/pidl/wscript
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
-import os, sys, Logs
+import os, Logs
 from samba_utils import MODE_755
 
 # This function checks if a perl module is installed on the system.
 def check_system_perl_module(conf, module, version=None):
     bundle_name = module.replace('::', '_')
     module_check = module
-    found = False
 
     # Create module string with version
     if version:
@@ -64,8 +63,6 @@ def build(bld):
 
     # use perl to build the manpages
     bld.env.pidl_srcdir = os.path.join(bld.srcnode.abspath(), 'pidl')
-
-    blib_bld = os.path.join(bld.srcnode.abspath(bld.env), 'pidl/blib')
 
     bld.SET_BUILD_GROUP('final')
     if 'POD2MAN' in bld.env and bld.env['POD2MAN'] != '':


### PR DESCRIPTION
The 'import *' statements make it more difficult to reason about
the modules and tends to conceal bugs. These changes enable running
Pyflakes against most of the Samba build scripts. A few misleading
unused variables have been removed in the process.

Signed-off-by: Thomas Nagy <tnagy@waf.io>