### PR TITLE
build:wafsamba: Removed the custom parse_flag override from the Samba scripts

### DIFF
--- a/third_party/waf/wafadmin/Tools/config_c.py
+++ b/third_party/waf/wafadmin/Tools/config_c.py
@@ -82,6 +82,10 @@ def parse_flags(line, uselib, env):
 		# RPATH later, and hence can potentially lead to linking
 		# in too old versions of our internal libs.
 		#
+		elif x == '-Wl,-rpath' or x == '-Wl,-R':
+			app('RPATH_' + uselib, lst.pop(0).lstrip('-Wl,'))
+		elif x.startswith('-Wl,-R,'):
+			app('RPATH_' + uselib, x[7:])
 		elif x.startswith('-Wl,-R'):
 			app('RPATH_' + uselib, x[6:])
 		elif x.startswith('-Wl,-rpath,'):
@@ -746,3 +750,4 @@ def cc_load_tools(conf):
 @conftest
 def cxx_load_tools(conf):
 	conf.check_tool('cxx')
+


### PR DESCRIPTION
The flags parsing fixes were backported to waf 1.5 from waf 1.8. There is no reason to maintain the flags parsing fixes in Samba.

Commit in Waf 1.5: https://github.com/waf-project/waf.waf15/commit/cab0f7eb725f37c84b36956f28403d583dba7802
The code in Waf 1.5 after the changes: https://github.com/waf-project/waf.waf15/blob/master/wafadmin/Tools/config_c.py#L85
The code in Waf 1.8: https://github.com/waf-project/waf/blob/master/waflib/Tools/c_config.py#L178

Signed-off-by: Thomas Nagy <tnagy@waf.io>