### PR TITLE
Remove unused modules and variables that complicate the build scripts

### DIFF
--- a/buildtools/wafsamba/samba_deps.py
+++ b/buildtools/wafsamba/samba_deps.py
@@ -260,15 +260,10 @@ def add_init_functions(self):
 
 
 def check_duplicate_sources(bld, tgt_list):
-    '''see if we are compiling the same source file more than once
-       without an allow_duplicates attribute'''
+    '''see if we are compiling the same source file more than once'''
 
     debug('deps: checking for duplicate sources')
-
     targets = LOCAL_CACHE(bld, 'TARGET_TYPE')
-    ret = True
-
-    global tstart
 
     for t in tgt_list:
         source_list = TO_LIST(getattr(t, 'source', ''))
@@ -286,7 +281,6 @@ def check_duplicate_sources(bld, tgt_list):
 
     # build a list of targets that each source file is part of
     for t in tgt_list:
-        sources = []
         if not targets[t.sname] in [ 'LIBRARY', 'BINARY', 'PYTHON' ]:
             continue
         for obj in t.add_objects:
@@ -306,7 +300,7 @@ def check_duplicate_sources(bld, tgt_list):
             if len(subsystems[s][tname]) > 1:
                 raise Utils.WafError("ERROR: source %s is in more than one subsystem of target '%s': %s" % (s, tname, subsystems[s][tname]))
 
-    return ret
+    return True
 
 
 def check_orphaned_targets(bld, tgt_list):

--- a/buildtools/wafsamba/samba_optimisation.py
+++ b/buildtools/wafsamba/samba_optimisation.py
@@ -266,24 +266,4 @@ def apply_lib_vars(self):
             if val:
                 self.env.append_value(v, val)
 
-@feature('cprogram', 'cshlib', 'cstaticlib')
-@after('apply_lib_vars')
-@before('apply_obj_vars')
-def samba_before_apply_obj_vars(self):
-    """before apply_obj_vars for uselib, this removes the standard pathes"""
 
-    def is_standard_libpath(env, path):
-        for _path in env.STANDARD_LIBPATH:
-            if _path == os.path.normpath(path):
-                return True
-        return False
-
-    v = self.env
-
-    for i in v['RPATH']:
-        if is_standard_libpath(v, i):
-            v['RPATH'].remove(i)
-
-    for i in v['LIBPATH']:
-        if is_standard_libpath(v, i):
-            v['LIBPATH'].remove(i)

--- a/buildtools/wafsamba/samba_utils.py
+++ b/buildtools/wafsamba/samba_utils.py
@@ -3,7 +3,7 @@
 
 import os, sys, re, fnmatch, shlex
 import Build, Options, Utils, Task, Logs, Configure
-from TaskGen import feature, before
+from TaskGen import feature, before, after
 from Configure import conf, ConfigurationContext
 from Logs import debug
 
@@ -680,3 +680,26 @@ def AD_DC_BUILD_IS_ENABLED(self):
     return False
 
 Build.BuildContext.AD_DC_BUILD_IS_ENABLED = AD_DC_BUILD_IS_ENABLED
+
+@feature('cprogram', 'cshlib', 'cstaticlib')
+@after('apply_lib_vars')
+@before('apply_obj_vars')
+def samba_before_apply_obj_vars(self):
+    """before apply_obj_vars for uselib, this removes the standard paths"""
+
+    def is_standard_libpath(env, path):
+        for _path in env.STANDARD_LIBPATH:
+            if _path == os.path.normpath(path):
+                return True
+        return False
+
+    v = self.env
+
+    for i in v['RPATH']:
+        if is_standard_libpath(v, i):
+            v['RPATH'].remove(i)
+
+    for i in v['LIBPATH']:
+        if is_standard_libpath(v, i):
+            v['LIBPATH'].remove(i)
+

--- a/dynconfig/wscript
+++ b/dynconfig/wscript
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import string, Logs, Utils, Options, sys, Build, os, intltool, optparse, textwrap
+import string, Logs, Utils, Options, Build, os, optparse, textwrap
 from samba_utils import EXPAND_VARIABLES, os_path_relpath
 
 class SambaIndentedHelpFormatter (optparse.IndentedHelpFormatter):


### PR DESCRIPTION
The changes remove unnecessary code that complicates running Samba on Waf 1.8. Please review and apply.