### PR TITLE
build:wafsamba: Remove samba_utils.runonce

### DIFF
--- a/buildtools/wafsamba/samba_autoconf.py
+++ b/buildtools/wafsamba/samba_autoconf.py
@@ -4,7 +4,7 @@ import os, sys
 import Build, Options, preproc, Logs
 from Configure import conf
 from TaskGen import feature
-from samba_utils import TO_LIST, GET_TARGET_TYPE, SET_TARGET_TYPE, runonce, unique_list, mkdir_p
+from samba_utils import TO_LIST, GET_TARGET_TYPE, SET_TARGET_TYPE, unique_list, mkdir_p
 
 missing_headers = set()
 
@@ -13,7 +13,6 @@ missing_headers = set()
 # to waf a bit easier for those used to autoconf
 # m4 files
 
-@runonce
 @conf
 def DEFINE(conf, d, v, add_to_cflags=False, quote=False):
     '''define a config option'''

--- a/buildtools/wafsamba/samba_bundled.py
+++ b/buildtools/wafsamba/samba_bundled.py
@@ -3,7 +3,7 @@
 import sys
 import Build, Options, Logs
 from Configure import conf
-from samba_utils import TO_LIST, runonce
+from samba_utils import TO_LIST
 
 def PRIVATE_NAME(bld, name, private_extension, private_library):
     '''possibly rename a library to include a bundled extension'''
@@ -108,7 +108,6 @@ def LIB_MUST_BE_PRIVATE(conf, libname):
     return ('ALL' in conf.env.PRIVATE_LIBS or
             libname in conf.env.PRIVATE_LIBS)
 
-@runonce
 @conf
 def CHECK_BUNDLED_SYSTEM_PKG(conf, libname, minversion='0.0.0',
         onlyif=None, implied_deps=None, pkg=None):
@@ -122,7 +121,6 @@ def CHECK_BUNDLED_SYSTEM_PKG(conf, libname, minversion='0.0.0',
                                      implied_deps=implied_deps,
                                      pkg=pkg)
 
-@runonce
 @conf
 def CHECK_BUNDLED_SYSTEM(conf, libname, minversion='0.0.0',
                          checkfunctions=None, headers=None, checkcode=None,
@@ -219,7 +217,6 @@ def CHECK_BUNDLED_SYSTEM(conf, libname, minversion='0.0.0',
 def tuplize_version(version):
     return tuple([int(x) for x in version.split(".")])
 
-@runonce
 @conf
 def CHECK_BUNDLED_SYSTEM_PYTHON(conf, libname, modulename, minversion='0.0.0'):
     '''check if a python module is available on the system and

--- a/buildtools/wafsamba/samba_perl.py
+++ b/buildtools/wafsamba/samba_perl.py
@@ -5,12 +5,6 @@ done = {}
 
 @conf
 def SAMBA_CHECK_PERL(conf, mandatory=True, version=(5,0,0)):
-    #
-    # TODO: use the @runonce mechanism for this.
-    # The problem is that @runonce currently does
-    # not seem to work together with @conf...
-    # So @runonce (and/or) @conf needs fixing.
-    #
     if "done" in done:
         return
     done["done"] = True

--- a/buildtools/wafsamba/samba_utils.py
+++ b/buildtools/wafsamba/samba_utils.py
@@ -35,22 +35,6 @@ def GET_TARGET_TYPE(ctx, target):
     return cache[target]
 
 
-######################################################
-# this is used as a decorator to make functions only
-# run once. Based on the idea from
-# http://stackoverflow.com/questions/815110/is-there-a-decorator-to-simply-cache-function-return-values
-def runonce(function):
-    runonce_ret = {}
-    def runonce_wrapper(*args):
-        if args in runonce_ret:
-            return runonce_ret[args]
-        else:
-            ret = function(*args)
-            runonce_ret[args] = ret
-            return ret
-    return runonce_wrapper
-
-
 def ADD_LD_LIBRARY_PATH(path):
     '''add something to LD_LIBRARY_PATH'''
     if 'LD_LIBRARY_PATH' in os.environ:

--- a/buildtools/wafsamba/wafsamba.py
+++ b/buildtools/wafsamba/wafsamba.py
@@ -674,7 +674,7 @@ Build.BuildContext.SAMBA_GENERATOR = SAMBA_GENERATOR
 
 
 
-@runonce
+@Utils.run_once
 def SETUP_BUILD_GROUPS(bld):
     '''setup build groups used to ensure that the different build
     phases happen consecutively'''

--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -203,7 +203,7 @@ def set_options(opt):
                     metavar="PYTHON", dest='EXTRA_PYTHON', default=None)
 
 
-@wafsamba.runonce
+@Utils.run_once
 def configure(conf):
     conf.env.hlist = []
     conf.env.srcdir = conf.srcdir

--- a/lib/replace/wscript
+++ b/lib/replace/wscript
@@ -14,7 +14,7 @@ while not os.path.exists(srcdir+'/buildtools') and len(srcdir.split('/')) < 5:
 sys.path.insert(0, srcdir + '/buildtools/wafsamba')
 
 import wafsamba, samba_dist
-import Options
+import Options, Utils
 
 samba_dist.DIST_DIRS('lib/replace buildtools:buildtools third_party/waf:third_party/waf')
 
@@ -23,7 +23,7 @@ def set_options(opt):
     opt.PRIVATE_EXTENSION_DEFAULT('')
     opt.RECURSE('buildtools/wafsamba')
 
-@wafsamba.runonce
+@Utils.run_once
 def configure(conf):
     conf.RECURSE('buildtools/wafsamba')
 


### PR DESCRIPTION
The decorator order matters in the following:
"""
@runonce
@conf
function()
"""

First, the @conf decorator binds the function to the configuration context
and then returns the same function. The @runonce decorator then takes
the output function and replaces it by another that performs caching. This new
function remains in the current script and is never bound to the configuration
context, so caching never occurs.

The declaration would have been correct if written like this:
"""
@conf
@runonce
function()
"""

Yet the decorator @run_once does not keep the function name (__name__), so the
annotation with @conf would fail. The straightforward approach is to remove
all the incorrect @runonce occurrences.

Besides that, the function Utils.run_once is already present in the Waf library,
and is sufficient for the current needs of the Samba code (it caches only the
first argument). Therefore samba_utils.runonce can be safely replaced by
Utils.run_once, which is also present in Waf 1.8.

Note: at runtime, only SETUP_BUILD_GROUPS seems to actually use caching.

Signed-off-by: Thomas Nagy <tnagy@waf.io>