### PR TITLE
build:wafsamba: Use the print_commands tool from upstream

### DIFF
--- a/buildtools/wafsamba/samba_utils.py
+++ b/buildtools/wafsamba/samba_utils.py
@@ -135,27 +135,6 @@ def dict_concat(d1, d2):
         if t not in d1:
             d1[t] = d2[t]
 
-
-def exec_command(self, cmd, **kw):
-    '''this overrides the 'waf -v' debug output to be in a nice
-    unix like format instead of a python list.
-    Thanks to ita on #waf for this'''
-    _cmd = cmd
-    if isinstance(cmd, list):
-        _cmd = ' '.join(cmd)
-    debug('runner: %s' % _cmd)
-    if self.log:
-        self.log.write('%s\n' % cmd)
-        kw['log'] = self.log
-    try:
-        if not kw.get('cwd', None):
-            kw['cwd'] = self.cwd
-    except AttributeError:
-        self.cwd = kw['cwd'] = self.bldnode.abspath()
-    return Utils.exec_command(cmd, **kw)
-Build.BuildContext.exec_command = exec_command
-
-
 def ADD_COMMAND(opt, name, function):
     '''add a new top level command to waf'''
     Utils.g_module.__dict__[name] = function

--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -216,6 +216,7 @@ def configure(conf):
     # load our local waf extensions
     conf.check_tool('gnu_dirs')
     conf.check_tool('wafsamba')
+    conf.check_tool('print_commands')
 
     conf.CHECK_CC_ENV()
 

--- a/third_party/waf/wafadmin/3rdparty/print_commands.py
+++ b/third_party/waf/wafadmin/3rdparty/print_commands.py
@@ -1,0 +1,25 @@
+#! /usr/bin/env python
+
+"""
+In this case, print the commands being executed as strings
+(the commands are usually lists, so this can be misleading)
+"""
+
+import Build, Utils, Logs
+
+def exec_command(self, cmd, **kw):
+	txt = cmd
+	if isinstance(cmd, list):
+		txt = ' '.join(cmd)
+	Logs.debug('runner: %s' % txt)
+	if self.log:
+		self.log.write('%s\n' % cmd)
+		kw['log'] = self.log
+	try:
+		if not kw.get('cwd', None):
+			kw['cwd'] = self.cwd
+	except AttributeError:
+		self.cwd = kw['cwd'] = self.bldnode.abspath()
+	return Utils.exec_command(cmd, **kw)
+Build.BuildContext.exec_command = exec_command
+


### PR DESCRIPTION
Using the print_commands tool makes it easier to upgrade to Waf 1.8.