### PR TITLE
build:wafsamba: Replace Options.is_install by bld.is_install

### DIFF
--- a/buildtools/wafsamba/samba_install.py
+++ b/buildtools/wafsamba/samba_install.py
@@ -4,7 +4,7 @@
 # library use
 
 import os
-import Options, Utils
+import Utils
 from TaskGen import feature, before, after
 from samba_utils import LIB_PATH, MODE_755, install_rpath, build_rpath
 
@@ -19,7 +19,7 @@ def install_binary(self):
     install_ldflags = install_rpath(self)
     build_ldflags   = build_rpath(bld)
 
-    if not Options.is_install:
+    if not self.bld.is_install:
         # just need to set rpath if we are not installing
         self.env.RPATH = build_ldflags
         return
@@ -68,7 +68,7 @@ def install_library(self):
         install_ldflags = install_rpath(self)
         build_ldflags   = build_rpath(bld)
 
-        if not Options.is_install or not getattr(self, 'samba_install', True):
+        if not self.bld.is_install or not getattr(self, 'samba_install', True):
             # just need to set the build rpath if we are not installing
             self.env.RPATH = build_ldflags
             return

--- a/buildtools/wafsamba/samba_patterns.py
+++ b/buildtools/wafsamba/samba_patterns.py
@@ -7,7 +7,7 @@ def write_version_header(task):
     '''print version.h contents'''
     src = task.inputs[0].srcpath(task.env)
 
-    version = samba_version_file(src, task.env.srcdir, env=task.env, is_install=task.env.is_install)
+    version = samba_version_file(src, task.env.srcdir, env=task.env, is_install=task.generator.bld.is_install)
     string = str(version)
 
     task.outputs[0].write(string)
@@ -25,7 +25,6 @@ def SAMBA_MKVERSION(bld, target):
                             source= 'VERSION',
                             target=target,
                             always=bld.is_install)
-    t.env.is_install = bld.is_install
 Build.BuildContext.SAMBA_MKVERSION = SAMBA_MKVERSION
 
 

--- a/buildtools/wafsamba/samba_wildcard.py
+++ b/buildtools/wafsamba/samba_wildcard.py
@@ -130,7 +130,6 @@ def fake_build_environment(info=True, flush=False):
 
     Options.commands['install'] = False
     Options.commands['uninstall'] = False
-    Options.is_install = False
 
     bld.is_install = 0 # False
 

--- a/buildtools/wafsamba/wafsamba.py
+++ b/buildtools/wafsamba/wafsamba.py
@@ -282,7 +282,7 @@ def SAMBA_LIBRARY(bld, libname, source,
             if not vscriptpath:
                 raise Utils.WafError("unable to find vscript path for %s" % vscript)
             bld.add_manual_dependency(fullpath, vscriptpath)
-            if Options.is_install:
+            if bld.is_install:
                 # also make the .inst file depend on the vscript
                 instname = apply_pattern(bundled_name + '.inst', bld.env.shlib_PATTERN)
                 bld.add_manual_dependency(bld.path.find_or_declare(instname), bld.path.find_or_declare(vscript))

--- a/dynconfig/wscript
+++ b/dynconfig/wscript
@@ -374,7 +374,7 @@ def dynconfig_cflags(bld, list=None):
         if list and not varname in list:
             continue
         value = bld.env[varname]
-        if not Options.is_install:
+        if not bld.is_install:
             override = get_override(bld)
             if varname in override:
                 value = os.path.join(bld.env.srcdir, override[varname])
@@ -399,7 +399,7 @@ def pathconfig_entities(bld, list=None):
         if list and not varname in list:
             continue
         value = bld.env[varname]
-        if not Options.is_install:
+        if not bld.is_install:
             override = get_override(bld)
             if varname in override:
                 value = os.path.join(bld.env.srcdir, override[varname])

--- a/lib/ldb/wscript
+++ b/lib/ldb/wscript
@@ -13,7 +13,7 @@ while not os.path.exists(srcdir+'/buildtools') and len(srcdir.split('/')) < 5:
     srcdir = srcdir + '/..'
 sys.path.insert(0, srcdir + '/buildtools/wafsamba')
 
-import wafsamba, samba_dist, Options, Utils
+import wafsamba, samba_dist, Utils
 
 samba_dist.DIST_DIRS('''lib/ldb:. lib/replace:lib/replace lib/talloc:lib/talloc
                         lib/tdb:lib/tdb lib/tdb:lib/tdb lib/tevent:lib/tevent
@@ -150,7 +150,7 @@ def build(bld):
             bld.INSTALL_FILES('${PYTHONARCHDIR}', '_ldb_text.py')
 
     if not bld.CONFIG_SET('USING_SYSTEM_LDB'):
-        if Options.is_install:
+        if bld.is_install:
             modules_dir = bld.EXPAND_VARIABLES('${LDB_MODULESDIR}')
         else:
             # when we run from the source directory, we want to use


### PR DESCRIPTION
Options.is_install is a deprecated module variable that is more
verbose than bld.is_install and complicates the Waf 1.8 upgrade.

Signed-off-by: Thomas Nagy <tnagy@waf.io>