### PR TITLE
build:wafsamba: Install named.conf only once

### DIFF
--- a/source4/setup/wscript_build
+++ b/source4/setup/wscript_build
@@ -7,6 +7,6 @@ bld.INSTALL_FILES('${SETUPDIR}', 'dns_update_list')
 bld.INSTALL_FILES('${SETUPDIR}', 'spn_update_list')
 
 for p in '''schema-map-* DB_CONFIG *.inf *.ldif *.reg *.zone *.conf *.php *.txt
-            named.conf named.conf.update named.conf.dlz'''.split():
+            named.conf.update named.conf.dlz'''.split():
     bld.INSTALL_WILDCARD('${SETUPDIR}', p)
 


### PR DESCRIPTION
The wildcard *.conf already lists named.conf. Adding files
more than once will cause unnecessary rebuilds and raise
errors in later Waf versions.

Signed-off-by: Thomas Nagy <tnagy@waf.io>