### PR TITLE
build:wafsamba: Waf 1.8 compatible declaration of 'mandatory' configuration tests

### DIFF
--- a/buildtools/wafsamba/samba_autoconf.py
+++ b/buildtools/wafsamba/samba_autoconf.py
@@ -100,6 +100,7 @@ def CHECK_HEADER(conf, h, add_headers=False, lib=None):
                      type='nolink',
                      execute=0,
                      ccflags=ccflags,
+                     mandatory=False,
                      includes=cpppath,
                      uselib=lib.upper(),
                      msg="Checking for header %s" % h)
@@ -485,6 +486,7 @@ def CHECK_LDFLAGS(conf, ldflags):
     return conf.check(fragment='int main(void) { return 0; }\n',
                       execute=0,
                       ldflags=ldflags,
+                      mandatory=False,
                       msg="Checking linker accepts %s" % ldflags)
 
 
@@ -568,9 +570,9 @@ int foo()
 
         (ccflags, ldflags, cpppath) = library_flags(conf, lib)
         if shlib:
-            res = conf.check(features='c cshlib', fragment=fragment, lib=lib, uselib_store=lib, ccflags=ccflags, ldflags=ldflags, uselib=lib.upper())
+            res = conf.check(features='c cshlib', fragment=fragment, lib=lib, uselib_store=lib, ccflags=ccflags, ldflags=ldflags, uselib=lib.upper(), mandatory=False)
         else:
-            res = conf.check(lib=lib, uselib_store=lib, ccflags=ccflags, ldflags=ldflags, uselib=lib.upper())
+            res = conf.check(lib=lib, uselib_store=lib, ccflags=ccflags, ldflags=ldflags, uselib=lib.upper(), mandatory=False)
 
         if not res:
             if mandatory:
@@ -670,6 +672,7 @@ def SAMBA_CONFIG_H(conf, path=None):
         execute=0,
         ccflags='-fstack-protector',
         ldflags='-fstack-protector',
+        mandatory=False,
         msg='Checking if toolchain accepts -fstack-protector'):
             conf.ADD_CFLAGS('-fstack-protector')
             conf.ADD_LDFLAGS('-fstack-protector')

--- a/buildtools/wafsamba/samba_conftests.py
+++ b/buildtools/wafsamba/samba_conftests.py
@@ -196,7 +196,7 @@ int foo(int v) {
     return v * 2;
 }
 '''
-    return conf.check(features='c cshlib',vnum="1",fragment=snip,msg=msg)
+    return conf.check(features='c cshlib',vnum="1",fragment=snip,msg=msg, mandatory=False)
 
 @conf
 def CHECK_NEED_LC(conf, msg):
@@ -258,7 +258,7 @@ int foo(int v) {
     ldb_module = PyImport_ImportModule("ldb");
     return v * 2;
 }'''
-    return conf.check(features='c cshlib',uselib='PYEMBED',fragment=snip,msg=msg)
+    return conf.check(features='c cshlib',uselib='PYEMBED',fragment=snip,msg=msg, mandatory=False)
 
 # this one is quite complex, and should probably be broken up
 # into several parts. I'd quite like to create a set of CHECK_COMPOUND()

--- a/buildtools/wafsamba/samba_python.py
+++ b/buildtools/wafsamba/samba_python.py
@@ -1,7 +1,7 @@
 # waf build tool for building IDL files with pidl
 
 import os
-import Build, Logs, Utils
+import Build, Logs, Utils, Configure
 from Configure import conf
 
 @conf
@@ -63,7 +63,12 @@ def SAMBA_CHECK_PYTHON_HEADERS(conf, mandatory=True):
     del(conf.env.defines['PYTHONARCHDIR'])
 
 def _check_python_headers(conf, mandatory):
-    conf.check_python_headers(mandatory=mandatory)
+    try:
+        Configure.ConfigurationError
+        conf.check_python_headers(mandatory=mandatory)
+    except Configure.ConfigurationError:
+        if mandatory:
+             raise
 
     if conf.env['PYTHON_VERSION'] > '3':
         abi_pattern = os.path.splitext(conf.env['pyext_PATTERN'])[0]


### PR DESCRIPTION
The configuration tests raise exceptions by default in later Waf versions,
but the Samba tests do not specify whether the errors should be raised or
not. This changes lifts the ambiguity.

Signed-off-by: Thomas Nagy <tnagy@waf.io>