### PR TITLE
Additional cleanups for Waf 1.8

### DIFF
--- a/buildtools/wafsamba/samba_abi.py
+++ b/buildtools/wafsamba/samba_abi.py
@@ -225,7 +225,7 @@ def abi_build_vscript(task):
 def ABI_VSCRIPT(bld, libname, abi_directory, version, vscript, abi_match=None):
     '''generate a vscript file for our public libraries'''
     if abi_directory:
-        source = bld.path.ant_glob('%s/%s-[0-9]*.sigs' % (abi_directory, libname))
+        source = bld.path.ant_glob('%s/%s-[0-9]*.sigs' % (abi_directory, libname), flat=True)
         def abi_file_key(path):
             return version_key(path[:-len(".sigs")].rsplit("-")[-1])
         source = sorted(source.split(), key=abi_file_key)

--- a/buildtools/wafsamba/samba_deps.py
+++ b/buildtools/wafsamba/samba_deps.py
@@ -360,7 +360,7 @@ def check_group_ordering(bld, tgt_list):
                 ret = False
 
     return ret
-
+Build.BuildContext.check_group_ordering = check_group_ordering
 
 def show_final_deps(bld, tgt_list):
     '''show the final dependencies for all targets'''
@@ -1159,7 +1159,7 @@ def check_project_rules(bld):
 
     debug("deps: check_duplicate_sources: %f" % (time.clock() - tstart))
 
-    if not check_group_ordering(bld, tgt_list):
+    if not bld.check_group_ordering(tgt_list):
         Logs.error("Bad group ordering - aborting")
         sys.exit(1)
 

--- a/buildtools/wafsamba/samba_install.py
+++ b/buildtools/wafsamba/samba_install.py
@@ -92,6 +92,7 @@ def install_library(self):
             t = self.clone(self.env)
             t.posted = False
             t.target += '.inst'
+            t.name = self.name + '.inst'
             self.env.RPATH = build_ldflags
         else:
             t = self

--- a/buildtools/wafsamba/wafsamba.py
+++ b/buildtools/wafsamba/wafsamba.py
@@ -727,7 +727,7 @@ def SAMBA_SCRIPT(bld, name, pattern, installdir, installname=None):
     '''used to copy scripts from the source tree into the build directory
        for use by selftest'''
 
-    source = bld.path.ant_glob(pattern)
+    source = bld.path.ant_glob(pattern, flat=True)
 
     bld.SET_BUILD_GROUP('build_source')
     for s in TO_LIST(source):
@@ -856,7 +856,7 @@ Build.BuildContext.INSTALL_FILES = INSTALL_FILES
 def INSTALL_WILDCARD(bld, destdir, pattern, chmod=MODE_644, flat=False,
                      python_fixup=False, exclude=None, trim_path=None):
     '''install a set of files matching a wildcard pattern'''
-    files=TO_LIST(bld.path.ant_glob(pattern))
+    files=TO_LIST(bld.path.ant_glob(pattern, flat=True))
     if trim_path:
         files2 = []
         for f in files:

--- a/docs-xml/wscript_build
+++ b/docs-xml/wscript_build
@@ -116,7 +116,7 @@ def smbdotconf_generate_parameter_list(task):
     save_file(parameter_all, t , create_dir=True)
     return 0
 
-articles = bld.path.ant_glob("smbdotconf/**/*.xml")
+articles = bld.path.ant_glob("smbdotconf/**/*.xml", flat=True)
 parameter_all = 'smbdotconf/parameters.all.xml'
 bld.SAMBA_GENERATOR(parameter_all,
                     source=articles,


### PR DESCRIPTION
* Specify whether node objects or flat lists in ant_glob
* Ensure that target clones get a different name
* Prepare to shortcut check_group_ordering in Waf 1.8

For an overview of the changes that are still required:
https://github.com/ita1024/samba/commit/b9cb58c392f4d470153a9ad45cc994ee8f703b9a