### PR TITLE
Add option for overlayfs "disable openfile inode check"

### DIFF
--- a/docs-xml/smbdotconf/tuning/disable_openfile_inode_check.xml
+++ b/docs-xml/smbdotconf/tuning/disable_openfile_inode_check.xml
@@ -1,5 +1,6 @@
-<samba:parameter name="disable openfile inode check" context="S" type="boolean"
-                 function="_disable_openfile_inode_check"
+<samba:parameter name="disable openfile inode check"
+                 type="boolean"
+                 context="S"
                  xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
 <description>
     <para>If this parameter is <constant>yes</constant> then openfile does not check dev and inode of file. Use yes with overlayfs.

--- a/docs-xml/smbdotconf/tuning/disable_openfile_inode_check.xml
+++ b/docs-xml/smbdotconf/tuning/disable_openfile_inode_check.xml
@@ -1,0 +1,10 @@
+<samba:parameter name="disable openfile inode check" context="S" type="boolean"
+                 function="_disable_openfile_inode_check"
+                 xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
+<description>
+    <para>If this parameter is <constant>yes</constant> then openfile does not check dev and inode of file. Use yes with overlayfs.
+    </para>
+</description>
+
+<value type="default">no</value>
+</samba:parameter>

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -902,6 +902,8 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
 	Globals.web_port = 901;
 
 	Globals.aio_max_threads = 100;
+	
+	Globals.disable_openfile_inode_check = false;
 
 	/* Now put back the settings that were set with lp_set_cmdline() */
 	apply_lp_set_cmdline();

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -244,6 +244,7 @@ static struct loadparm_service sDefault =
 	.kernel_share_modes = true,
 	.durable_handles = true,
 	.param_opt = NULL,
+	.disable_openfile_inode_check = false,
 	.dummy = ""
 };
 
@@ -903,8 +904,6 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
 
 	Globals.aio_max_threads = 100;
 	
-	Globals.disable_openfile_inode_check = false;
-
 	/* Now put back the settings that were set with lp_set_cmdline() */
 	apply_lp_set_cmdline();
 }

--- a/source3/smbd/open.c
+++ b/source3/smbd/open.c
@@ -2805,7 +2805,7 @@ static NTSTATUS open_file_ntcreate(connection_struct *conn,
 		file_existed = false;
 	}
 
-	if (file_existed && !check_same_dev_ino(&saved_stat, &smb_fname->st)) {
+	if (file_existed && !lp_disable_openfile_inode_check(SNUM(conn)) && !check_same_dev_ino(&saved_stat, &smb_fname->st)) {
 		/*
 		 * The file did exist, but some other (local or NFS)
 		 * process either renamed/unlinked and re-created the


### PR DESCRIPTION
 Add a option disable openfile inode check.

I use samba over overlayfs. 
When users try to open file for write, they will get NT_STATUS_ACCESS_DENIED and file opens for read only. 
Because open_file_ntcreate: file %s - dev/ino mismatch.

With disable openfile inode check = true, users can openfile for write.
I build a time machine of share, with overlayfs and hard links.
