### PR TITLE
Remove posixAccount from samdb.py

### DIFF
--- a/python/samba/samdb.py
+++ b/python/samba/samdb.py
@@ -419,7 +419,6 @@ member: %s
                 loginshell, nisdomain, unixhome))):
             ldbmessage2 = ldb.Message()
             ldbmessage2.dn = ldb.Dn(self, user_dn)
-            ldbmessage2["objectClass"] = ldb.MessageElement('posixAccount', ldb.FLAG_MOD_ADD, 'objectClass')
             if uid is not None:
                 ldbmessage2["uid"] = ldb.MessageElement(str(uid), ldb.FLAG_MOD_REPLACE, 'uid')
             if uidnumber is not None:

--- a/source4/setup/dns_update_list
+++ b/source4/setup/dns_update_list
@@ -34,6 +34,8 @@ ${IF_GC}SRV            _gc._tcp.${SITE}._sites.${DNSFOREST}                  ${H
 ${IF_GC}SRV            _ldap._tcp.${SITE}._sites.gc._msdcs.${DNSFOREST}      ${HOSTNAME} 3268
 
 # RW DNS servers
+${IF_RWDNS_DOMAIN}A    ${DNSDOMAIN}                                          $IP
+${IF_RWDNS_DOMAIN}NS   ${DNSDOMAIN}                                          ${HOSTNAME}
 ${IF_RWDNS_DOMAIN}A    DomainDnsZones.${DNSDOMAIN}                           $IP
 ${IF_RWDNS_DOMAIN}AAAA DomainDnsZones.${DNSDOMAIN}                           $IP
 ${IF_RWDNS_DOMAIN}SRV  _ldap._tcp.DomainDnsZones.${DNSDOMAIN}                ${HOSTNAME} 389
@@ -41,6 +43,7 @@ ${IF_RWDNS_DOMAIN}SRV  _ldap._tcp.DomainDnsZones.${DNSDOMAIN}                ${H
 ${IF_DNS_DOMAIN}SRV    _ldap._tcp.${SITE}._sites.DomainDnsZones.${DNSDOMAIN} ${HOSTNAME} 389
 
 # RW DNS servers
+${IF_RWDNS_FOREST}NS   _msdcs.${DNSFOREST}                                   ${HOSTNAME}
 ${IF_RWDNS_FOREST}A    ForestDnsZones.${DNSFOREST}                           $IP
 ${IF_RWDNS_FOREST}AAAA ForestDnsZones.${DNSFOREST}                           $IP
 ${IF_RWDNS_FOREST}SRV  _ldap._tcp.ForestDnsZones.${DNSFOREST}                ${HOSTNAME} 389


### PR DESCRIPTION
This will stop the adding of the totally unnecessary  posixAccount objectClass when adding/updating a user.

Signed-off-by: Rowland Penny rpenny@samba.org