### PR TITLE
If samlogon for trusted child domain user fails attempt to reroute re…

### DIFF
--- a/nsswitch/winbind_struct_protocol.h
+++ b/nsswitch/winbind_struct_protocol.h
@@ -224,6 +224,13 @@ typedef struct winbindd_gr {
 /* Flag to tell winbind the NTLMv2 blob is too big for the struct and is in the
  * extra_data field */
 #define WBFLAG_BIG_NTLMV2_BLOB		0x00010000
+/*
+ * Flag to tell winbind a previous error is stored in the
+ * extra_data field. This is used to pass any KRB5 error (which occured in
+ * trusted domain winbindd child) to the primary domain winbindd child
+ * which is processing the samlogon.
+ */
+#define WBFLAG_INTERNAL_PREV_KRB5_ERROR	0x00020000
 
 #define WINBINDD_MAX_EXTRA_DATA (128*1024)
 


### PR DESCRIPTION
…quest

When kerboros authentication fails we may attempt to fallback to
samlogon.  However schannel netlogon connections from a domain child
winbindd to the domain controller when that domain is not 'our'
domain are dissallowed and thus the credentials are not available.
The samlogon request when this happens cannot be serviced. This patch
detects if the samlogon fallback will occur for a non primary domain
winbindd child, in this case it will return a status of
NT_STATUS_MORE_PROCESSING_REQUIRED to the parent.
The parent then will then retry the authentication by chosing and sending
the request to a domain child that should be able to handle it.

Signed-off-by: Noel Power noel.power@suse.com
