### PR TITLE
Cloud build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ env:
   - TASK=tevent
   - TASK=pidl
 
+# Fail everything after the first job fails
+matrix:
+  fast_finish: true
+
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install --assume-yes screen git build-essential libacl1-dev libattr1-dev libblkid-dev libgnutls-dev libreadline-dev python-dev libpam0g-dev python-dnspython gdb pkg-config libpopt-dev libldap2-dev dnsutils libbsd-dev attr krb5-user docbook-xsl libcups2-dev acl bison debhelper docbook-xml docbook-xsl flex libaio-dev libbsd-dev libcap-dev libcups2-dev libncurses5-dev libpam0g-dev libpopt-dev libreadline-dev perl perl-modules libparse-yapp-perl pkg-config python-all-dev python-dnspython xsltproc zlib1g-dev autoconf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+dist: trusty
+
+sudo: true
+
+cache: ccache
+
+# Everything except samba and ctdb (long tests)
+env:
+  - TASK=samba-xc
+  - TASK=samba-ctdb
+  - TASK=samba-libs
+  - TASK=samba-static
+  - TASK=ldb
+  - TASK=tdb
+  - TASK=talloc
+  - TASK=replace
+  - TASK=tevent
+  - TASK=pidl
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install --assume-yes screen git build-essential libacl1-dev libattr1-dev libblkid-dev libgnutls-dev libreadline-dev python-dev libpam0g-dev python-dnspython gdb pkg-config libpopt-dev libldap2-dev dnsutils libbsd-dev attr krb5-user docbook-xsl libcups2-dev acl bison debhelper docbook-xml docbook-xsl flex libaio-dev libbsd-dev libcap-dev libcups2-dev libncurses5-dev libpam0g-dev libpopt-dev libreadline-dev perl perl-modules libparse-yapp-perl pkg-config python-all-dev python-dnspython xsltproc zlib1g-dev autoconf
+
+script:
+ - git fetch --unshallow
+ - ./script/autobuild.py --tail --testbase=/tmp $TASK
+

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -122,23 +122,23 @@ tasks = {
                       # retry with all modules shared
                       ("allshared-distclean", "make distclean", "text/plain"),
                       ("allshared-configure", samba_libs_configure_samba + " --with-shared-modules=ALL", "text/plain"),
-                      ("allshared-make", "make", "text/plain")],
+                      ("allshared-make", "make -j", "text/plain")],
 
     "samba-static" : [
                       ("random-sleep", "script/random-sleep.sh 60 600", "text/plain"),
                       # build with all modules static
                       ("allstatic-configure", "./configure.developer " + samba_configure_params + " --with-static-modules=ALL", "text/plain"),
-                      ("allstatic-make", "make", "text/plain"),
+                      ("allstatic-make", "make -j", "text/plain"),
 
                       # retry without any required modules
                       ("none-distclean", "make distclean", "text/plain"),
                       ("none-configure", "./configure.developer " + samba_configure_params + " --with-static-modules=!FORCED,!DEFAULT --with-shared-modules=!FORCED,!DEFAULT", "text/plain"),
-                      ("none-make", "make", "text/plain"),
+                      ("none-make", "make -j", "text/plain"),
 
                       # retry with nonshared smbd and smbtorture
                       ("nonshared-distclean", "make distclean", "text/plain"),
                       ("nonshared-configure", "./configure.developer " + samba_configure_params + " --bundled-libraries=talloc,tdb,pytdb,ldb,pyldb,tevent,pytevent --with-static-modules=ALL --nonshared-binary=smbtorture,smbd/smbd", "text/plain"),
-                      ("nonshared-make", "make", "text/plain")],
+                      ("nonshared-make", "make -j", "text/plain")],
 
     "ldb" : [
               ("random-sleep", "../../script/random-sleep.sh 60 600", "text/plain"),

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -720,7 +720,25 @@ blist.tarlogs("logs.tar.gz")
 if options.email is not None:
     email_failure(status, failed_task, failed_stage, failed_tag, errstr,
                   elapsed_time, log_base=options.log_base)
+else:
+    elapsed_minutes = elapsed_time / 60.0
+    print '''
 
+####################################################################
+
+AUTOBUILD FAILURE
+
+Your autobuild on %s failed after %.1f minutes
+when trying to test %s with the following error:
+
+   %s
+
+the autobuild has been abandoned. Please fix the error and resubmit.
+
+####################################################################
+
+''' % (platform.node(), elapsed_minutes, failed_task, errstr)
+    
 cleanup()
 print(errstr)
 print("Logs in logs.tar.gz")

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -26,6 +26,7 @@ builddirs = {
     "samba-xc" : ".",
     "samba-ctdb" : ".",
     "samba-libs"  : ".",
+    "samba-static"  : ".",
     "ldb"     : "lib/ldb",
     "tdb"     : "lib/tdb",
     "talloc"  : "lib/talloc",
@@ -37,7 +38,7 @@ builddirs = {
     "retry"   : "."
     }
 
-defaulttasks = [ "ctdb", "samba", "samba-xc", "samba-ctdb", "samba-libs", "ldb", "tdb", "talloc", "replace", "tevent", "pidl" ]
+defaulttasks = [ "ctdb", "samba", "samba-xc", "samba-ctdb", "samba-libs", "samba-static", "ldb", "tdb", "talloc", "replace", "tevent", "pidl" ]
 
 samba_configure_params = " --picky-developer ${PREFIX} --with-profiling-data"
 
@@ -121,21 +122,22 @@ tasks = {
                       # retry with all modules shared
                       ("allshared-distclean", "make distclean", "text/plain"),
                       ("allshared-configure", samba_libs_configure_samba + " --with-shared-modules=ALL", "text/plain"),
-                      ("allshared-make", "make", "text/plain"),
+                      ("allshared-make", "make", "text/plain")],
 
-                      # retry with all modules static
-                      ("allstatic-distclean", "make distclean", "text/plain"),
-                      ("allstatic-configure", samba_libs_configure_samba + " --with-static-modules=ALL", "text/plain"),
+    "samba-static" : [
+                      ("random-sleep", "script/random-sleep.sh 60 600", "text/plain"),
+                      # build with all modules static
+                      ("allstatic-configure", "./configure.developer " + samba_configure_params + " --with-static-modules=ALL", "text/plain"),
                       ("allstatic-make", "make", "text/plain"),
 
                       # retry without any required modules
                       ("none-distclean", "make distclean", "text/plain"),
-                      ("none-configure", samba_libs_configure_samba + " --with-static-modules=!FORCED,!DEFAULT --with-shared-modules=!FORCED,!DEFAULT", "text/plain"),
+                      ("none-configure", "./configure.developer " + samba_configure_params + " --with-static-modules=!FORCED,!DEFAULT --with-shared-modules=!FORCED,!DEFAULT", "text/plain"),
                       ("none-make", "make", "text/plain"),
 
                       # retry with nonshared smbd and smbtorture
                       ("nonshared-distclean", "make distclean", "text/plain"),
-                      ("nonshared-configure", samba_libs_configure_base + " --bundled-libraries=talloc,tdb,pytdb,ldb,pyldb,tevent,pytevent --with-static-modules=ALL --nonshared-binary=smbtorture,smbd/smbd", "text/plain"),
+                      ("nonshared-configure", "./configure.developer " + samba_configure_params + " --bundled-libraries=talloc,tdb,pytdb,ldb,pyldb,tevent,pytevent --with-static-modules=ALL --nonshared-binary=smbtorture,smbd/smbd", "text/plain"),
                       ("nonshared-make", "make", "text/plain")],
 
     "ldb" : [

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -222,7 +222,7 @@ def run_cmd(cmd, dir=".", show=None, output=False, checkfail=True):
 class builder(object):
     '''handle build of one directory'''
 
-    def __init__(self, name, sequence):
+    def __init__(self, name, sequence, cp=True):
         self.name = name
         self.dir = builddirs[name]
 
@@ -245,7 +245,10 @@ class builder(object):
         cleanup_list.append(self.prefix)
         os.makedirs(self.sdir)
         run_cmd("rm -rf %s" % self.sdir)
-        run_cmd("git clone --recursive --shared %s %s" % (test_master, self.sdir), dir=test_master, show=True)
+        if cp:
+            run_cmd("cp --recursive --link --archive %s %s" % (test_master, self.sdir), dir=test_master, show=True)
+        else:
+            run_cmd("git clone --recursive --shared %s %s" % (test_master, self.sdir), dir=test_master, show=True)
         self.start_next()
 
     def start_next(self):
@@ -284,7 +287,7 @@ class buildlist(object):
             os.environ['AUTOBUILD_RANDOM_SLEEP_OVERRIDE'] = '1'
 
         for n in tasknames:
-            b = builder(n, tasks[n])
+            b = builder(n, tasks[n], cp=n is not "pidl")
             self.tlist.append(b)
         if options.retry:
             rebase_remote = "rebaseon"


### PR DESCRIPTION
I would like to have Samba start being tested on travis-ci.org, so that we know if pull requests break the tree before they are reviewed, not after.

I realise that the make -j in the static and samba-libs builds may be an issue, but otherwise these come far to close to the 50min timeout (they take 23mins with -j). I have already split up the samba-libs build into samba-libs and samba-static for similar reasons.

The main samba build and test is not done at this time, as we need to come up with a new quicktest that can run in 20mins or so.

The autobuild.py script has been adjusted to use cp --link rather than git checkout to reduce disk use.

The CTDB and samba builds have been omitted until they are reliable.

Please review/push
