### PR TITLE
acess based share enum: handle permission set in configuration files

### DIFF
--- a/source3/rpc_server/srvsvc/srv_srvsvc_nt.c
+++ b/source3/rpc_server/srvsvc/srv_srvsvc_nt.c
@@ -480,8 +480,13 @@ static bool is_enumeration_allowed(struct pipes_struct *p,
     if (!lp_access_based_share_enum(snum))
         return true;
 
+    if (!user_ok_token(p->session_info->unix_info->unix_name,
+                       p->session_info->info->domain_name,
+                       p->session_info->security_token, snum))
+        return false;
+
     return share_access_check(p->session_info->security_token,
-			      lp_servicename(talloc_tos(), snum),
+                              lp_servicename(talloc_tos(), snum),
 			      FILE_READ_DATA, NULL);
 }
 


### PR DESCRIPTION
** access based share enum** not work with permission set in config file.
change function is_enumeration_allowed to check  permissions set by
fields: valid users, invalid users, only user.

Signed-off-by: Alberto Maria Fiaschi <alberto.fiaschi@estar.toscana.it>