### PR TITLE
ctdb: Fix detection of gnukfreebsd

### DIFF
--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -315,7 +315,7 @@ def build(bld):
         CTDB_SYSTEM_SRC = bld.SUBDIR('common', 'system_aix.c')
     elif sys.platform.startswith('freebsd'):
         CTDB_SYSTEM_SRC = bld.SUBDIR('common', 'system_freebsd.c')
-    elif sys.platform == 'kfreebsd':
+    elif sys.platform.startswith('gnukfreebsd'):
         CTDB_SYSTEM_SRC = bld.SUBDIR('common', 'system_kfreebsd.c')
     elif sys.platform == 'gnu':
         CTDB_SYSTEM_SRC = bld.SUBDIR('common', 'system_gnu.c')


### PR DESCRIPTION
GNU/kFreeBSD's platform name is 'gnukfreebsd', not just 'kfreebsd'.

Reviewed-by: Andrew Bartlett <abartlet@samba.org>

I originally sent this patch to https://bugs.debian.org/802621#15
where I was asked to send it upstream.  Thanks!