### PR TITLE
build:wafsamba: Remove ambiguous 'if x in conf.env' constructs

### DIFF
--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -490,12 +490,12 @@ struct foo bar = { .y = 'X', .x = 1 };
     if not conf.CHECK_LARGEFILE():
         raise Utils.WafError('Samba requires large file support support, but not available on this platform: sizeof(off_t) < 8')
 
-    if 'HAVE_STDDEF_H' in conf.env and 'HAVE_STDLIB_H' in conf.env:
+    if conf.env.HAVE_STDDEF_H and conf.env.HAVE_STDLIB_H:
         conf.DEFINE('STDC_HEADERS', 1)
 
     conf.CHECK_HEADERS('sys/time.h time.h', together=True)
 
-    if 'HAVE_SYS_TIME_H' in conf.env and 'HAVE_TIME_H' in conf.env:
+    if conf.env.HAVE_SYS_TIME_H and conf.env.HAVE_TIME_H:
         conf.DEFINE('TIME_WITH_SYS_TIME', 1)
 
     # cope with different extensions for libraries

--- a/source3/wscript
+++ b/source3/wscript
@@ -137,7 +137,7 @@ long ret = splice(0,0,1,0,400,SPLICE_F_MOVE);
 
     # Check for inotify support
     conf.CHECK_HEADERS('sys/inotify.h')
-    if "HAVE_SYS_INOTIFY_H" in conf.env:
+    if conf.env.HAVE_SYS_INOTIFY_H:
         conf.DEFINE('HAVE_INOTIFY', 1)
 
     # Check for kernel change notify support
@@ -309,7 +309,7 @@ int main(int argc, char **argv)
     conf.CHECK_STRUCTURE_MEMBER('struct stat', 'st_flags', define='HAVE_STAT_ST_FLAGS',
                                 headers='sys/types.h sys/stat.h unistd.h')
 
-    if "HAVE_BLKCNT_T" in conf.env:
+    if conf.env.HAVE_BLKCNT_T:
         conf.CHECK_CODE('''
         static int test_array[1 - 2 * !(((long int)(sizeof(blkcnt_t))) <= 4)];''',
                 'SIZEOF_BLKCNT_T_4',
@@ -317,7 +317,7 @@ int main(int argc, char **argv)
                 msg="Checking whether blkcnt_t is 32 bit")
 
     # If sizeof is 4 it can't be 8
-    if "HAVE_BLKCNT_T" in conf.env:
+    if conf.env.HAVE_BLKCNT_T:
         if not conf.CONFIG_SET('SIZEOF_BLKCNT_T_4'):
             conf.CHECK_CODE('''
             static int test_array[1 - 2 * !(((long int)(sizeof(blkcnt_t))) <= 8)];''',
@@ -328,7 +328,7 @@ int main(int argc, char **argv)
     # Check for POSIX capability support
     conf.CHECK_FUNCS_IN('cap_get_proc', 'cap', headers='sys/capability.h')
 
-    if "HAVE_SYS_CAPABILITY_H" in conf.env:
+    if conf.env.HAVE_SYS_CAPABILITY_H:
         conf.CHECK_CODE('''
         cap_t cap;
         cap_value_t vals[1];

--- a/source4/lib/tls/wscript
+++ b/source4/lib/tls/wscript
@@ -44,7 +44,7 @@ def configure(conf):
                            args='"gnutls >= 1.4.0 gnutls != 2.2.4 gnutls != 2.8.0 gnutls != 2.8.1" --cflags --libs',
                            msg='Checking for gnutls >= 1.4.0 and broken versions', mandatory=False)
 
-    if 'HAVE_GNUTLS' in conf.env:
+    if conf.env.HAVE_GNUTLS:
         conf.DEFINE('ENABLE_GNUTLS', 1)
     else:
         if 'AD_DC_BUILD_IS_ENABLED' in conf.env:
@@ -67,7 +67,7 @@ def configure(conf):
                      headers='gnutls/gnutls.h', lib='gnutls')
 
     # GnuTLS3 moved to libnettle, so only do this in the < 3.0 case
-    if not 'HAVE_GNUTLS3' in conf.env:
+    if conf.env.HAVE_GNUTLS3:
         conf.CHECK_FUNCS_IN('gcry_control', 'gcrypt', headers='gcrypt.h')
         conf.CHECK_FUNCS_IN('gpg_err_code_from_errno', 'gpg-error')
     else:


### PR DESCRIPTION
Configuration values such as HAVE_STDDEF_H can be set to 0
to indicate a test failure. Waf 1.5 has a few bugs that
prevent configuration tests from setting such values
consistently on failures.

Consequently, conditions such as 'if conf.env.VARNAME' must be
used to indicate that config test successes are expected.
Note that conf.env.VARNAME always returns an empty list (False value)
when no variable is defined so there are no risk of raising
AttributeError/KeyError exceptions.
