### PR TITLE
Fix bug #11658 - ZFS snapshots access denied

### DIFF
--- a/source3/modules/vfs_shadow_copy2.c
+++ b/source3/modules/vfs_shadow_copy2.c
@@ -1164,7 +1164,7 @@ static bool check_access_snapdir(struct vfs_handle_struct *handle,
 					&smb_fname,
 					false,
 					SEC_DIR_LIST);
-	if (!NT_STATUS_IS_OK(status)) {
+	if (status == NT_STATUS_ACCESS_DENIED) {
 		DEBUG(0,("user does not have list permission "
 			"on snapdir %s\n",
 			smb_fname.base_name));


### PR DESCRIPTION
Check the return status of smbd_check_access_rights more precisely, to allow access to ZFS snapshots, where NT_STATUS_NOT_SUPPORTED is returned and previously regarded as access denied.

Signed-off-by: QIU Quan <jackqq@gmail.com>