### PR TITLE
Correctly set cli->raw_status for libsmbclient in SMB2 code

### DIFF
--- a/source3/libsmb/cli_smb2_fnum.c
+++ b/source3/libsmb/cli_smb2_fnum.c
@@ -262,6 +262,7 @@ NTSTATUS cli_smb2_create_fnum_recv(struct tevent_req *req, uint16_t *pfnum,
 	NTSTATUS status;
 
 	if (tevent_req_is_nterror(req, &status)) {
+		state->cli->raw_status = status;
 		return status;
 	}
 	if (pfnum != NULL) {
@@ -270,6 +271,7 @@ NTSTATUS cli_smb2_create_fnum_recv(struct tevent_req *req, uint16_t *pfnum,
 	if (cr != NULL) {
 		*cr = state->cr;
 	}
+	state->cli->raw_status = NT_STATUS_OK;
 	return NT_STATUS_OK;
 }
 
@@ -390,7 +392,11 @@ static void cli_smb2_close_fnum_done(struct tevent_req *subreq)
 
 NTSTATUS cli_smb2_close_fnum_recv(struct tevent_req *req)
 {
-	return tevent_req_simple_recv_ntstatus(req);
+	struct cli_smb2_close_fnum_state *state = tevent_req_data(
+		req, struct cli_smb2_close_fnum_state);
+	NTSTATUS status = tevent_req_simple_recv_ntstatus(req);
+	state->cli->raw_status = status;
+	return status;
 }
 
 NTSTATUS cli_smb2_close_fnum(struct cli_state *cli, uint16_t fnum)
@@ -2302,6 +2308,7 @@ NTSTATUS cli_smb2_read_recv(struct tevent_req *req,
 				req, struct cli_smb2_read_state);
 
 	if (tevent_req_is_nterror(req, &status)) {
+		state->cli->raw_status = status;
 		return status;
 	}
 	/*
@@ -2311,6 +2318,7 @@ NTSTATUS cli_smb2_read_recv(struct tevent_req *req,
 	 */
 	*received = (ssize_t)state->received;
 	*rcvbuf = state->buf;
+	state->cli->raw_status = NT_STATUS_OK;
 	return NT_STATUS_OK;
 }
 
@@ -2409,6 +2417,7 @@ NTSTATUS cli_smb2_write_recv(struct tevent_req *req,
 	NTSTATUS status;
 
 	if (tevent_req_is_nterror(req, &status)) {
+		state->cli->raw_status = status;
 		tevent_req_received(req);
 		return status;
 	}
@@ -2416,6 +2425,7 @@ NTSTATUS cli_smb2_write_recv(struct tevent_req *req,
 	if (pwritten != NULL) {
 		*pwritten = (size_t)state->written;
 	}
+	state->cli->raw_status = NT_STATUS_OK;
 	tevent_req_received(req);
 	return NT_STATUS_OK;
 }
@@ -2573,11 +2583,13 @@ NTSTATUS cli_smb2_writeall_recv(struct tevent_req *req,
 	NTSTATUS status;
 
 	if (tevent_req_is_nterror(req, &status)) {
+		state->cli->raw_status = status;
 		return status;
 	}
 	if (pwritten != NULL) {
 		*pwritten = (size_t)state->written;
 	}
+	state->cli->raw_status = NT_STATUS_OK;
 	return NT_STATUS_OK;
 }
 
@@ -2838,12 +2850,14 @@ NTSTATUS cli_smb2_splice_recv(struct tevent_req *req, off_t *written)
 	NTSTATUS status;
 
 	if (tevent_req_is_nterror(req, &status)) {
+		state->cli->raw_status = status;
 		tevent_req_received(req);
 		return status;
 	}
 	if (written != NULL) {
 		*written = state->written;
 	}
+	state->cli->raw_status = NT_STATUS_OK;
 	tevent_req_received(req);
 	return NT_STATUS_OK;
 }


### PR DESCRIPTION
The SMB2 file handling code wasn't correctly setting raw_status, which is used by libsmbclient to report file open errors etc.

The bug was originally found when attempting to do a `stat()` on a non-existing file behind a DFS link. Before this patch, the code returned was 22 (EINVAL), rather than the expected 2 (ENOENT), since the SMB result status wasn't set into the cli object. The easiest way to demonstrate this is to run the attached test program against a Samba server configured with DFS (for an easy test environment, run `docker pull xenopathic/samba-dfs && docker run -e SMB_USER=test -e SMB_PASSWORD=test --rm xenopathic/samba-dfs`). Make sure smb.conf contains `client max protocol = SMB2` or higher of course.

The fix for the actual noticed bug is the line added to `cli_smb2_create_fnum_recv()`, but I added similar lines to all other `cli_smb2_*_recv()` functions since the behaviour should be the same.

Test program:

```
#include <libsmbclient.h>
#include <stdio.h>
#include <errno.h>
#include <string.h>

const char *guser = "test";
const char *gpass = "test";
const char *url = "smb://172.17.0.2/dfs/public/Test.pdf";

void authfn(SMBCCTX *ctx, const char *server, const char *share, char *wkgp, int wkgplen, char *user, int userlen, char *pass, int passlen) {
    strcpy(user, guser);
    strcpy(pass, gpass);
}

int main() {
    SMBCCTX *ctx = smbc_new_context();
    smbc_setFunctionAuthDataWithContext(ctx, authfn);
    ctx = smbc_init_context(ctx);

    smbc_stat_fn smbc_stat = smbc_getFunctionStat(ctx);

    struct stat statbuf;
    printf("smbc_stat(): %d\n", smbc_stat(ctx, url, &statbuf));
    printf("errno: %d\n", errno);

    smbc_free_context(ctx, 1);

    return 0;
}
```

Signed-off-by: Robin McCorkell robin@mccorkell.me.uk
