### PR TITLE
Add build option for default smbpasswd location

### DIFF
--- a/dynconfig/wscript
+++ b/dynconfig/wscript
@@ -254,6 +254,8 @@ dynconfig = {
     'SMB_PASSWD_FILE' : {
          'STD-PATH':  '${PRIVATE_DIR}/smbpasswd',
          'FHS-PATH':  '${PRIVATE_DIR}/smbpasswd',
+         'OPTION':    '--with-smbpasswd-file',
+         'HELPTEXT':  'Where to put the smbpasswd file',
          'DELAY':     True,
     },
 }


### PR DESCRIPTION
This part of the FHS patch was never submitted from https://bugs.debian.org/705449

Signed-off-by: Ivo De Decker ivo.dedecker@ugent.be
