### PR TITLE
vfs_fruit: Add capability to advertise FULLSYNC

### DIFF
--- a/docs-xml/manpages/vfs_fruit.8.xml
+++ b/docs-xml/manpages/vfs_fruit.8.xml
@@ -214,6 +214,34 @@
 	  </varlistentry>
 
 	  <varlistentry>
+	    <term>fruit:time machine = [ yes | no ]</term>
+	    <listitem>
+	      <para>Controls if Time Machine support via the FULLSYNC volume
+	      capability is advertised to clients.</para>
+
+	      <itemizedlist>
+		<listitem><para><command>yes</command> - Enables Time Machine
+		support for this share. Also registers the share with mDNS in
+		case Samba is built with mDNS support.</para></listitem>
+
+		<listitem><para><command>no (default)</command> Disables
+		advertising Time Machine support.</para></listitem>
+
+	      </itemizedlist>
+
+	      <para>This option enforces the following settings per share (or
+	      for all shares if enabled globally):</para>
+	      <itemizedlist>
+		<listitem><para><command>durable handles = yes</command></para></listitem>
+		<listitem><para><command>kernel oplocks = no</command></para></listitem>
+		<listitem><para><command>kernel share modes = no</command></para></listitem>
+		<listitem><para><command>posix locking = no</command></para></listitem>
+	      </itemizedlist>
+
+	    </listitem>
+	  </varlistentry>
+
+	  <varlistentry>
 	    <term>fruit:metadata = [ stream | netatalk ]</term>
 	    <listitem>
 	      <para>Controls where the OS X metadata stream is stored:</para>

--- a/libcli/smb/smb2_create_ctx.h
+++ b/libcli/smb/smb2_create_ctx.h
@@ -42,5 +42,6 @@
 /* "AAPL" Volume Capabilities bitmap */
 #define SMB2_CRTCTX_AAPL_SUPPORT_RESOLVE_ID 1
 #define SMB2_CRTCTX_AAPL_CASE_SENSITIVE     2
+#define SMB2_CRTCTX_AAPL_FULL_SYNC          4
 
 #endif

--- a/source3/smbd/avahi_register.c
+++ b/source3/smbd/avahi_register.c
@@ -24,12 +24,47 @@
 #include <avahi-client/client.h>
 #include <avahi-client/publish.h>
 #include <avahi-common/error.h>
+#include <avahi-common/malloc.h>
+#include <avahi-common/strlst.h>
 
 struct avahi_state_struct {
 	struct AvahiPoll *poll;
 	AvahiClient *client;
 	AvahiEntryGroup *entry_group;
 	uint16_t port;
+};
+
+static void *avahi_allocator_ctx = NULL;
+
+static void * avahi_allocator_malloc(size_t size)
+{
+	return talloc_size(avahi_allocator_ctx, size);
+}
+
+static void avahi_allocator_free(void *p)
+{
+	TALLOC_FREE(p);
+}
+
+static void * avahi_allocator_realloc(void *p, size_t size)
+{
+	return talloc_realloc_size(avahi_allocator_ctx, p, size);
+}
+
+static void * avahi_allocator_calloc(size_t count, size_t size)
+{
+	void *p = talloc_array_size(avahi_allocator_ctx, size, count);
+	if (p) {
+		memset(p, 0, size * count);
+	}
+	return p;
+}
+
+static const struct AvahiAllocator avahi_talloc_allocator = {
+	&avahi_allocator_malloc,
+	&avahi_allocator_free,
+	&avahi_allocator_realloc,
+	&avahi_allocator_calloc
 };
 
 static void avahi_entry_group_callback(AvahiEntryGroup *g,
@@ -70,7 +105,13 @@ static void avahi_client_callback(AvahiClient *c, AvahiClientState status,
 	int error;
 
 	switch (status) {
-	case AVAHI_CLIENT_S_RUNNING:
+	case AVAHI_CLIENT_S_RUNNING: {
+		int snum;
+		int num_services = lp_numservices();
+		int dk = 0;
+		AvahiStringList *adisk = NULL;
+		AvahiStringList *adisk2 = NULL;
+
 		DBG_DEBUG("AVAHI_CLIENT_S_RUNNING\n");
 
 		state->entry_group = avahi_entry_group_new(
@@ -94,6 +135,53 @@ static void avahi_client_callback(AvahiClient *c, AvahiClientState status,
 			break;
 		}
 
+		for (snum = 0; snum < num_services; snum++) {
+			if (lp_snum_ok(snum) &&
+			    lp_parm_bool(snum, "fruit", "time machine", false))
+			{
+				adisk2 = avahi_string_list_add_printf(
+					    adisk, "dk%d=adVN=%s,adVF=0x82",
+					    dk++, lp_const_servicename(snum));
+				if (adisk2 == NULL) {
+					DBG_DEBUG("avahi_string_list_add_printf"
+						  "failed: returned NULL\n");
+					avahi_string_list_free(adisk);
+					avahi_entry_group_free(state->entry_group);
+					state->entry_group = NULL;
+					break;
+				}
+				adisk = adisk2;
+				adisk2 = NULL;
+			}
+		}
+		if (dk > 0) {
+			adisk2 = avahi_string_list_add(adisk, "sys=adVF=0x100");
+			if (adisk2 == NULL) {
+				DBG_DEBUG("avahi_string_list_add failed: "
+					  "returned NULL\n");
+				avahi_string_list_free(adisk);
+				avahi_entry_group_free(state->entry_group);
+				state->entry_group = NULL;
+				break;
+			}
+			adisk = adisk2;
+			adisk2 = NULL;
+
+			error = avahi_entry_group_add_service_strlst(
+				    state->entry_group, AVAHI_IF_UNSPEC,
+				    AVAHI_PROTO_UNSPEC, 0, lp_netbios_name(),
+				    "_adisk._tcp", NULL, NULL, 0, adisk);
+			avahi_string_list_free(adisk);
+			adisk = NULL;
+			if (error != AVAHI_OK) {
+				DBG_DEBUG("avahi_entry_group_add_service_strlst "
+					  "failed: %s\n", avahi_strerror(error));
+				avahi_entry_group_free(state->entry_group);
+				state->entry_group = NULL;
+				break;
+			}
+		}
+
 		error = avahi_entry_group_commit(state->entry_group);
 		if (error != AVAHI_OK) {
 			DBG_DEBUG("avahi_entry_group_commit failed: %s\n",
@@ -103,6 +191,7 @@ static void avahi_client_callback(AvahiClient *c, AvahiClientState status,
 			break;
 		}
 		break;
+	}
 	case AVAHI_CLIENT_FAILURE:
 		error = avahi_client_errno(c);
 
@@ -138,6 +227,12 @@ void *avahi_start_register(TALLOC_CTX *mem_ctx, struct tevent_context *ev,
 {
 	struct avahi_state_struct *state;
 	int error;
+
+	avahi_allocator_ctx = talloc_new(mem_ctx);
+	if (avahi_allocator_ctx == NULL) {
+		return NULL;
+	}
+	avahi_set_allocator(&avahi_talloc_allocator);
 
 	state = talloc(mem_ctx, struct avahi_state_struct);
 	if (state == NULL) {


### PR DESCRIPTION
Add the capability to advertise FULLSYNC volume capabilities
to clients that request them. This is mainly used for supporting
Mac OS Time Machine backups from clients. The capability does
not perform any additional action.
