### PR TITLE
Samba bug 12443: Active Directory account locked when using winbind refresh tickets

### DIFF
--- a/docs-xml/smbdotconf/winbind/winbindpasswordkinit.xml
+++ b/docs-xml/smbdotconf/winbind/winbindpasswordkinit.xml
@@ -1,0 +1,18 @@
+<samba:parameter name="winbind password kinit"
+                 context="G"
+                 type="list"
+                 xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
+<description>
+
+	<para>This parameter controls which user for which Winbind will use
+	cached passwords to refresh Kerberos Tickets retrieved using the
+	<parameter moreinfo="none">pam_winbind</parameter> module. This option
+	requires that <smbconfoption name="winbind refresh tickets"/> also be
+	enabled.
+
+</para>
+</description>
+
+<value type="default">*</value>
+<value type="example">tux, affe</value>
+</samba:parameter>

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -821,6 +821,8 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
 	Globals.winbind_expand_groups = 0;
 	Globals.winbind_nss_info = str_list_make_v3_const(NULL, "template", NULL);
 	Globals.winbind_refresh_tickets = false;
+	Globals.winbind_password_kinit =
+		str_list_make_v3_const(NULL, "*", NULL);
 	Globals.winbind_offline_logon = false;
 	Globals.winbind_scan_trusted_domains = true;
 


### PR DESCRIPTION
Resolves an issue where user accounts get locked out due to winbind refreshing tickets using cached passwords (after the password has been modified, but the wrong password is still cached).

It's my opinion that the password kinit should be disabled by default. Does anyone disagree?