### PR TITLE
packaging: Avoid timeout for nmbd if started offline with systemd

### DIFF
--- a/packaging/systemd/nmb.service
+++ b/packaging/systemd/nmb.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/sysconfig/samba
 ExecStart=/usr/sbin/nmbd $NMBDOPTIONS
 ExecReload=/usr/bin/kill -HUP $MAINPID
 LimitCORE=infinity
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If no network connection appears within DefaultTimeoutStartSec
(~ 90s) after startup, nmbd fails to notify systemd and will
therefore get killed.

Signed-off-by: Andreas Oberritter <obi@opendreambox.org>