### PR TITLE
Add missing import of sys in ms_schema.py

### DIFF
--- a/python/samba/ms_schema.py
+++ b/python/samba/ms_schema.py
@@ -117,7 +117,8 @@ def __read_folded_line(f, buffer):
 
 def __read_raw_entries(f):
     """reads an LDIF entry, only unfolding lines"""
-
+    import sys
+    
     # will not match options after the attribute type
     attr_type_re = re.compile("^([A-Za-z]+[A-Za-z0-9-]*):")
 


### PR DESCRIPTION
If we get an error, we try to print it, but sys module is missing