### PR TITLE
Disable python v2 (for travis-ci test)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - TASK=samba-libs
   - TASK=samba-static
   - TASK=samba-o3
+  - TASK=samba-nopython
   - TASK=ldb
   - TASK=tdb
   - TASK=talloc

--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -196,6 +196,10 @@ def set_options(opt):
                    help='tag release in git at the same time',
                    type='string', action='store', dest='TAG_RELEASE')
 
+    opt.add_option('--disable-python',
+                    help='do not generate python modules',
+                    action='store_true', dest='disable_python', default=False)
+
     opt.add_option('--extra-python', type=str,
                     help=("build selected libraries for the specified "
                           "additional version of Python "
@@ -279,7 +283,13 @@ def configure(conf):
     conf.env.AUTOCONF_HOST  = Options.options.AUTOCONF_HOST
     conf.env.AUTOCONF_PROGRAM_PREFIX = Options.options.AUTOCONF_PROGRAM_PREFIX
 
+    conf.env.disable_python = Options.options.disable_python
+
     conf.env.EXTRA_PYTHON = Options.options.EXTRA_PYTHON
+
+    if (conf.env.disable_python and conf.env.EXTRA_PYTHON):
+        Logs.error('ERROR: cannot specify both --disable-python and --extra-python.')
+        sys.exit(1)
 
     if (conf.env.AUTOCONF_HOST and
         conf.env.AUTOCONF_BUILD and

--- a/ctdb/wscript
+++ b/ctdb/wscript
@@ -107,8 +107,8 @@ def configure(conf):
     if conf.env.standalone_ctdb:
         conf.SAMBA_CHECK_PERL(mandatory=True)
 
-        conf.SAMBA_CHECK_PYTHON(mandatory=True, version=(2,5,0))
-        conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=True)
+        conf.SAMBA_CHECK_PYTHON(mandatory=False, version=(2,5,0))
+        conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=False)
 
     if conf.CHECK_FOR_THIRD_PARTY():
         conf.RECURSE('third_party/popt')

--- a/lib/ldb/wscript
+++ b/lib/ldb/wscript
@@ -46,7 +46,7 @@ def configure(conf):
     conf.find_program('xsltproc', var='XSLTPROC')
     conf.check_tool('python')
     conf.check_python_version((2,4,2))
-    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=True)
+    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=not conf.env.disable_python)
 
     # where does the default LIBDIR end up? in conf.env somewhere?
     #
@@ -55,10 +55,16 @@ def configure(conf):
     conf.env.standalone_ldb = conf.IN_LAUNCH_DIR()
 
     if not conf.env.standalone_ldb:
-        if conf.CHECK_BUNDLED_SYSTEM_PKG('pyldb-util', minversion=VERSION,
+        if conf.env.disable_python:
+            if conf.CHECK_BUNDLED_SYSTEM_PKG('ldb', minversion=VERSION,
+                                         onlyif='talloc tdb tevent',
+                                         implied_deps='replace talloc tdb tevent'):
+                conf.define('USING_SYSTEM_LDB', 1)
+        else:
+            if conf.CHECK_BUNDLED_SYSTEM_PKG('pyldb-util', minversion=VERSION,
                                      onlyif='talloc tdb tevent',
                                      implied_deps='replace talloc tdb tevent ldb'):
-            conf.define('USING_SYSTEM_PYLDB_UTIL', 1)
+                conf.define('USING_SYSTEM_PYLDB_UTIL', 1)
             if conf.CHECK_BUNDLED_SYSTEM_PKG('ldb', minversion=VERSION,
                                          onlyif='talloc tdb tevent pyldb-util',
                                          implied_deps='replace talloc tdb tevent'):
@@ -120,11 +126,10 @@ def build(bld):
         bld.env.PACKAGE_VERSION = VERSION
         bld.env.PKGCONFIGDIR = '${LIBDIR}/pkgconfig'
 
-    if not bld.env.disable_python:
-        if not bld.CONFIG_SET('USING_SYSTEM_PYLDB_UTIL'):
-            for env in bld.gen_python_environments(['PKGCONFIGDIR']):
-                name = bld.pyembed_libname('pyldb-util')
-                bld.SAMBA_LIBRARY(name,
+    if not bld.CONFIG_SET('USING_SYSTEM_PYLDB_UTIL'):
+        for env in bld.gen_python_environments(['PKGCONFIGDIR']):
+            name = bld.pyembed_libname('pyldb-util')
+            bld.SAMBA_LIBRARY(name,
                                   deps='ldb',
                                   source='pyldb_util.c',
                                   public_headers=('' if private_library else 'pyldb.h'),
@@ -133,15 +138,17 @@ def build(bld):
                                   private_library=private_library,
                                   pc_files='pyldb-util.pc',
                                   pyembed=True,
+                                  enabled=bld.PYTHON_BUILD_IS_ENABLED(),
                                   abi_directory='ABI',
                                   abi_match='pyldb_*')
 
-                if not bld.CONFIG_SET('USING_SYSTEM_LDB'):
+            if not bld.CONFIG_SET('USING_SYSTEM_LDB'):
                     bld.SAMBA_PYTHON('pyldb', 'pyldb.c',
                                      deps='ldb ' + name,
                                      realname='ldb.so',
                                      cflags='-DPACKAGE_VERSION=\"%s\"' % VERSION)
 
+        if bld.PYTHON_BUILD_IS_ENABLED():
             for env in bld.gen_python_environments(['PKGCONFIGDIR']):
                 bld.SAMBA_SCRIPT('_ldb_text.py',
                                  pattern='_ldb_text.py',

--- a/lib/talloc/wscript
+++ b/lib/talloc/wscript
@@ -32,9 +32,6 @@ def set_options(opt):
         opt.add_option('--enable-talloc-compat1',
                        help=("Build talloc 1.x.x compat library [False]"),
                        action="store_true", dest='TALLOC_COMPAT1', default=False)
-        opt.add_option('--disable-python',
-                       help=("disable the pytalloc module"),
-                       action="store_true", dest='disable_python', default=False)
 
 
 def configure(conf):
@@ -46,13 +43,12 @@ def configure(conf):
     conf.define('TALLOC_BUILD_VERSION_MINOR', int(VERSION.split('.')[1]))
     conf.define('TALLOC_BUILD_VERSION_RELEASE', int(VERSION.split('.')[2]))
 
-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
-
     if not conf.env.standalone_talloc:
         if conf.CHECK_BUNDLED_SYSTEM_PKG('talloc', minversion=VERSION,
                                      implied_deps='replace'):
             conf.define('USING_SYSTEM_TALLOC', 1)
-        if conf.CHECK_BUNDLED_SYSTEM_PKG('pytalloc-util', minversion=VERSION,
+        if not conf.env.disable_python and \
+            conf.CHECK_BUNDLED_SYSTEM_PKG('pytalloc-util', minversion=VERSION,
                                      implied_deps='talloc replace'):
             conf.define('USING_SYSTEM_PYTALLOC_UTIL', 1)
 
@@ -126,7 +122,7 @@ def build(bld):
                           private_library=private_library,
                           manpages='man/talloc.3')
 
-    if not bld.CONFIG_SET('USING_SYSTEM_PYTALLOC_UTIL') and not bld.env.disable_python:
+    if not bld.CONFIG_SET('USING_SYSTEM_PYTALLOC_UTIL'):
         for env in bld.gen_python_environments(['PKGCONFIGDIR']):
             name = bld.pyembed_libname('pytalloc-util')
 
@@ -140,16 +136,19 @@ def build(bld):
                 abi_match='pytalloc_* _pytalloc_*',
                 private_library=private_library,
                 public_headers=('' if private_library else 'pytalloc.h'),
-                pc_files='pytalloc-util.pc'
+                pc_files='pytalloc-util.pc',
+                enabled=bld.PYTHON_BUILD_IS_ENABLED()
                 )
             bld.SAMBA_PYTHON('pytalloc',
                             'pytalloc.c',
                             deps='talloc ' + name,
+                            enabled=bld.PYTHON_BUILD_IS_ENABLED(),
                             realname='talloc.so')
 
             bld.SAMBA_PYTHON('test_pytalloc',
                             'test_pytalloc.c',
                             deps='pytalloc',
+                            enabled=bld.PYTHON_BUILD_IS_ENABLED(),
                             realname='_test_pytalloc.so',
                             install=False)
 

--- a/lib/tdb/wscript
+++ b/lib/tdb/wscript
@@ -60,10 +60,6 @@ def set_options(opt):
                    help=("Disable the use of pthread robust mutexes"),
                    action="store_true", dest='disable_tdb_mutex_locking',
                    default=False)
-    if opt.IN_LAUNCH_DIR():
-        opt.add_option('--disable-python',
-                       help=("disable the pytdb module"),
-                       action="store_true", dest='disable_python', default=False)
 
 
 def configure(conf):
@@ -82,10 +78,9 @@ def configure(conf):
                                      implied_deps='replace'):
             conf.define('USING_SYSTEM_TDB', 1)
             conf.env.building_tdb = False
-            if conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytdb', 'tdb', minversion=VERSION):
+            if not conf.env.disable_python and \
+                conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytdb', 'tdb', minversion=VERSION):
                 conf.define('USING_SYSTEM_PYTDB', 1)
-
-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
 
     if (conf.CONFIG_SET('HAVE_ROBUST_MUTEXES') and
         conf.env.building_tdb and

--- a/lib/tevent/wscript
+++ b/lib/tevent/wscript
@@ -22,10 +22,6 @@ def set_options(opt):
     opt.PRIVATE_EXTENSION_DEFAULT('tevent', noextension='tevent')
     opt.RECURSE('lib/replace')
     opt.RECURSE('lib/talloc')
-    if opt.IN_LAUNCH_DIR():
-        opt.add_option('--disable-python',
-                       help=("disable the pytevent module"),
-                       action="store_true", dest='disable_python', default=False)
 
 
 def configure(conf):
@@ -38,7 +34,8 @@ def configure(conf):
         if conf.CHECK_BUNDLED_SYSTEM_PKG('tevent', minversion=VERSION,
                                      onlyif='talloc', implied_deps='replace talloc'):
             conf.define('USING_SYSTEM_TEVENT', 1)
-            if conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytevent', 'tevent', minversion=VERSION):
+            if not conf.env.disable_python and \
+                conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytevent', 'tevent', minversion=VERSION):
                 conf.define('USING_SYSTEM_PYTEVENT', 1)
 
     if conf.CHECK_FUNCS('epoll_create', headers='sys/epoll.h'):
@@ -60,8 +57,6 @@ def configure(conf):
 
     if not conf.CONFIG_SET('USING_SYSTEM_TEVENT'):
         conf.DEFINE('TEVENT_NUM_SIGNALS', tevent_num_signals)
-
-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
 
     if not conf.env.disable_python:
         # also disable if we don't have the python libs installed

--- a/python/wscript_build
+++ b/python/wscript_build
@@ -5,7 +5,8 @@ bld.SAMBA_LIBRARY('samba_python',
 	deps='LIBPYTHON pytalloc-util pyrpc_util',
 	grouping_library=True,
 	private_library=True,
-	pyembed=True)
+	pyembed=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED())
 
 bld.SAMBA_SUBSYSTEM('LIBPYTHON',
 	source='modules.c',
@@ -13,7 +14,7 @@ bld.SAMBA_SUBSYSTEM('LIBPYTHON',
 	init_function_sentinel='{NULL,NULL}',
 	deps='talloc',
 	pyext=True,
-	)
+	enabled=bld.PYTHON_BUILD_IS_ENABLED())
 
 
 bld.SAMBA_PYTHON('python_glue',
@@ -22,7 +23,8 @@ bld.SAMBA_PYTHON('python_glue',
 	realname='samba/_glue.so'
 	)
 
-for env in bld.gen_python_environments():
+if bld.PYTHON_BUILD_IS_ENABLED():
+    for env in bld.gen_python_environments():
 	# install out various python scripts for use by make test
 	bld.SAMBA_SCRIPT('samba_python_files',
 	                 pattern='samba/**/*.py',

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -32,6 +32,7 @@ builddirs = {
     "samba-static"  : ".",
     "samba-test-only"  : ".",
     "samba-systemkrb5"  : ".",
+    "samba-nopython"  : ".",
     "ldb"     : "lib/ldb",
     "tdb"     : "lib/tdb",
     "talloc"  : "lib/talloc",
@@ -43,7 +44,7 @@ builddirs = {
     "retry"   : "."
     }
 
-defaulttasks = [ "ctdb", "samba", "samba-xc", "samba-o3", "samba-ctdb", "samba-libs", "samba-static", "samba-systemkrb5", "ldb", "tdb", "talloc", "replace", "tevent", "pidl" ]
+defaulttasks = [ "ctdb", "samba", "samba-xc", "samba-o3", "samba-ctdb", "samba-libs", "samba-static", "samba-systemkrb5", "samba-nopython", "ldb", "tdb", "talloc", "replace", "tevent", "pidl" ]
 
 if os.environ.get("AUTOBUILD_SKIP_SAMBA_O3", "0") == "1":
     defaulttasks.remove("samba-o3")
@@ -173,6 +174,21 @@ tasks = {
                       # we currently cannot run a full make test, a limited list of tests could be run
                       # via "make test TESTS=sometests"
                       ("test", "make test FAIL_IMMEDIATELY=1 TESTS='samba3.*ktest'", "text/plain"),
+                      ("install", "make install", "text/plain"),
+                      ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
+                      ("clean", "make clean", "text/plain")
+                      ],
+
+    # Test Samba without python still builds.  When this test fails
+    # due to more use of Python, the expectations is that the newly
+    # failing part of the code should be disabled when
+    # --disable-python is set (rather than major work being done to
+    # support this environment).  The target here is for vendors
+    # shipping a minimal smbd.
+    "samba-nopython" : [
+                      ("random-sleep", "script/random-sleep.sh 60 600", "text/plain"),
+                      ("configure", "./configure.developer --picky-developer ${PREFIX} --with-profiling-data --disable-python --without-ad-dc", "text/plain"),
+                      ("make", "make -j", "text/plain"),
                       ("install", "make install", "text/plain"),
                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                       ("clean", "make clean", "text/plain")

--- a/source4/lib/policy/wscript_build
+++ b/source4/lib/policy/wscript_build
@@ -6,7 +6,8 @@ bld.SAMBA_LIBRARY('samba-policy',
 	public_deps='ldb samba-net',
 	vnum='0.0.1',
 	pyembed=True,
-	public_headers='policy.h'
+	public_headers='policy.h',
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 bld.SAMBA_PYTHON('py_policy',

--- a/source4/libnet/wscript_build
+++ b/source4/libnet/wscript_build
@@ -4,7 +4,8 @@ bld.SAMBA_LIBRARY('samba-net',
 	source='libnet.c libnet_passwd.c libnet_time.c libnet_rpc.c libnet_join.c libnet_site.c libnet_become_dc.c libnet_unbecome_dc.c libnet_vampire.c libnet_samdump.c libnet_samsync_ldb.c libnet_user.c libnet_group.c libnet_share.c libnet_lookup.c libnet_domain.c userinfo.c groupinfo.c userman.c groupman.c prereq_domain.c libnet_samsync.c',
 	autoproto='libnet_proto.h',
 	public_deps='samba-credentials dcerpc dcerpc-samr RPC_NDR_LSA RPC_NDR_SRVSVC RPC_NDR_DRSUAPI cli_composite LIBCLI_RESOLVE LIBCLI_FINDDCS cli_cldap LIBCLI_FINDDCS gensec_schannel LIBCLI_AUTH ndr smbpasswdparser PROVISION LIBCLI_SAMSYNC LIBTSOCKET',
-	private_library=True
+	private_library=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 

--- a/source4/librpc/wscript_build
+++ b/source4/librpc/wscript_build
@@ -178,6 +178,7 @@ bld.SAMBA_SUBSYSTEM('pyrpc_util',
 	source='rpc/pyrpc_util.c',
 	public_deps='pytalloc-util pyparam_util dcerpc MESSAGING',
 	pyext=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED(),
 	)
 
 
@@ -393,9 +394,10 @@ bld.SAMBA_PYTHON('python_dcerpc_smb_acl',
 	realname='samba/dcerpc/smb_acl.so'
 	)
 
-bld.SAMBA_SCRIPT('python_dcerpc_init',
+if bld.PYTHON_BUILD_IS_ENABLED():
+    bld.SAMBA_SCRIPT('python_dcerpc_init',
                  pattern='rpc/dcerpc.py',
                  installdir='python/samba/dcerpc',
                  installname='__init__.py')
 
-bld.INSTALL_FILES('${PYTHONARCHDIR}/samba/dcerpc', 'rpc/dcerpc.py', destname='__init__.py')
+    bld.INSTALL_FILES('${PYTHONARCHDIR}/samba/dcerpc', 'rpc/dcerpc.py', destname='__init__.py')

--- a/source4/param/wscript_build
+++ b/source4/param/wscript_build
@@ -4,6 +4,7 @@ bld.SAMBA_SUBSYSTEM('PROVISION',
 	source='provision.c pyparam.c',
 	deps='LIBPYTHON pyparam_util ldb pytalloc-util pyldb-util',
 	pyext=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED(),
 	)
 
 
@@ -51,6 +52,7 @@ bld.SAMBA_SUBSYSTEM('pyparam_util',
 	source='pyparam_util.c',
 	deps='LIBPYTHON samba-hostconfig pytalloc-util',
 	pyext=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED(),
 	)
 
 bld.SAMBA_LIBRARY('shares',

--- a/source4/torture/drs/wscript_build
+++ b/source4/torture/drs/wscript_build
@@ -6,6 +6,7 @@ bld.SAMBA_MODULE('TORTURE_DRS',
 	subsystem='smbtorture',
 	init_function='torture_drs_init',
 	deps='samba-util ldb POPT_SAMBA samba-errors torture ldbsamba talloc dcerpc ndr NDR_DRSUAPI gensec samba-hostconfig RPC_NDR_DRSUAPI DSDB_MODULE_HELPERS asn1util samdb NDR_DRSBLOBS samba-credentials samdb-common LIBCLI_RESOLVE LP_RESOLVE torturemain',
-	internal_module=True
+	internal_module=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 

--- a/source4/torture/local/wscript_build
+++ b/source4/torture/local/wscript_build
@@ -32,5 +32,6 @@ bld.SAMBA_MODULE('TORTURE_LOCAL',
 	subsystem='smbtorture',
 	init_function='torture_local_init',
 	deps=TORTURE_LOCAL_DEPS,
-	internal_module=True
+	internal_module=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)

--- a/source4/torture/wscript_build
+++ b/source4/torture/wscript_build
@@ -14,7 +14,8 @@ bld.SAMBA_MODULE('TORTURE_BASIC',
 	deps='LIBCLI_SMB popt POPT_CREDENTIALS TORTURE_UTIL smbclient-raw TORTURE_RAW',
 	internal_module=True,
 	autoproto='basic/proto.h',
-	init_function='torture_base_init'
+	init_function='torture_base_init',
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 
@@ -24,7 +25,8 @@ bld.SAMBA_MODULE('TORTURE_RAW',
 	subsystem='smbtorture',
 	init_function='torture_raw_init',
 	deps='LIBCLI_SMB LIBCLI_LSA LIBCLI_SMB_COMPOSITE popt POPT_CREDENTIALS TORTURE_UTIL',
-	internal_module=True
+	internal_module=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 bld.RECURSE('smb2')
@@ -67,7 +69,8 @@ bld.SAMBA_SUBSYSTEM('TORTURE_NDR',
                   ndr/charset.c
 		  ''',
 	autoproto='ndr/proto.h',
-	deps='torture krb5samba'
+	deps='torture krb5samba',
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 torture_rpc_backupkey = ''
@@ -181,7 +184,8 @@ bld.SAMBA_MODULE('torture_rpc',
                       RPC_NDR_BACKUPKEY
                       RPC_NDR_WINSPOOL
                       ''' + ntvfs_specific['deps'],
-                 internal_module=True)
+                 internal_module=True,
+                 enabled=bld.PYTHON_BUILD_IS_ENABLED())
 
 bld.RECURSE('drs')
 bld.RECURSE('dns')
@@ -192,7 +196,8 @@ bld.SAMBA_MODULE('TORTURE_RAP',
 	subsystem='smbtorture',
 	init_function='torture_rap_init',
 	deps='TORTURE_UTIL LIBCLI_SMB NDR_RAP LIBCLI_RAP',
-	internal_module=True
+	internal_module=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 bld.SAMBA_MODULE('TORTURE_DFS',
@@ -252,7 +257,8 @@ bld.SAMBA_MODULE('TORTURE_NBT',
 	subsystem='smbtorture',
 	init_function='torture_nbt_init',
 	deps='LIBCLI_SMB cli-nbt LIBCLI_DGRAM LIBCLI_WREPL torture_rpc',
-	internal_module=True
+	internal_module=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 
@@ -262,7 +268,8 @@ bld.SAMBA_MODULE('TORTURE_NET',
 	subsystem='smbtorture',
 	init_function='torture_net_init',
 	deps='samba-net popt POPT_CREDENTIALS torture_rpc PROVISION',
-	internal_module=True
+	internal_module=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 
@@ -272,7 +279,8 @@ bld.SAMBA_MODULE('TORTURE_NTP',
 	subsystem='smbtorture',
 	init_function='torture_ntp_init',
 	deps='popt POPT_CREDENTIALS torture_rpc',
-	internal_module=True
+	internal_module=True,
+	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
 
 bld.SAMBA_MODULE('TORTURE_VFS',
@@ -290,6 +298,7 @@ bld.SAMBA_SUBSYSTEM('torturemain',
                     source='smbtorture.c torture.c shell.c',
                     subsystem_name='smbtorture',
                     deps='torture popt POPT_SAMBA POPT_CREDENTIALS dcerpc LIBCLI_SMB SMBREADLINE ' + TORTURE_MODULES,
+                    enabled=bld.PYTHON_BUILD_IS_ENABLED()
                     )
 
 bld.SAMBA_BINARY('smbtorture',
@@ -297,7 +306,8 @@ bld.SAMBA_BINARY('smbtorture',
                  manpages='man/smbtorture.1',
                  private_headers='smbtorture.h',
                  deps='torturemain torture popt POPT_SAMBA POPT_CREDENTIALS dcerpc LIBCLI_SMB SMBREADLINE ' + TORTURE_MODULES,
-                 pyembed=True
+                 pyembed=True,
+                 enabled=bld.PYTHON_BUILD_IS_ENABLED()
                  )
 
 bld.SAMBA_BINARY('gentest',

--- a/testsuite/headers/test_headers.c
+++ b/testsuite/headers/test_headers.c
@@ -23,7 +23,9 @@
 
 #define _GNU_SOURCE 1
 
-#include <Python.h>
+#ifdef HAVE_PYTHON_H
+# include <Python.h>
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/wscript
+++ b/wscript
@@ -107,8 +107,12 @@ def configure(conf):
     conf.SAMBA_CHECK_PERL(mandatory=True)
     conf.find_program('xsltproc', var='XSLTPROC')
 
+    if conf.env.disable_python:
+        if not (Options.options.without_ad_dc):
+            raise Utils.WafError('--disable-python requires --without-ad-dc')
+
     conf.SAMBA_CHECK_PYTHON(mandatory=True, version=(2, 6, 0))
-    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=True)
+    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=(not conf.env.disable_python))
 
     if sys.platform == 'darwin' and not conf.env['HAVE_ENVIRON_DECL']:
         # Mac OSX needs to have this and it's also needed that the python is compiled with this


### PR DESCRIPTION
As per the thread on samba-technical@ , moving to PR's to allow autobuilds to confirm readiness.