### PR TITLE
    Fix FreeBSD/Darwin & Linux sendfile.

### DIFF
--- a/source3/lib/sendfile.c
+++ b/source3/lib/sendfile.c
@@ -106,7 +106,7 @@ ssize_t sys_sendfile_native(int tofd, int fromfd, off_t offset, size_t count, st
 
 	if (hv->iov_len > 0) {
 		if((nwritten = send(tofd, hv->iov_base, hv->iov_len, MSG_MORE)) == -1) {
-			if(errno != EINTR || errno != EAGAIN || errno != EWOULDBLOCK) {
+			if(errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
 				return -1;
 			} else {
 				return 0;
@@ -132,7 +132,7 @@ ssize_t sys_sendfile_native(int tofd, int fromfd, off_t offset, size_t count, st
 				*/
 			errno = EINTR; /* Normally we can never return this. */
 		}
-		if (errno != EINTR || errno != EAGAIN || errno != EWOULDBLOCK) {
+		if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
 			return -1;
 		}
 		nwritten = 0;

--- a/source3/lib/sendfile.c
+++ b/source3/lib/sendfile.c
@@ -116,9 +116,9 @@ ssize_t sys_sendfile_native(int tofd, int fromfd, off_t offset, size_t count, st
 		if(nwritten < hv->iov_len) {
 			return nwritten;
 		}
-	}
 
-	total += nwritten;
+		total += nwritten;
+	}
 
 	if((nwritten = sendfile(tofd, fromfd, &offset, count)) == -1) {
 		if (errno == ENOSYS || errno == EINVAL) {

--- a/source3/lib/sendfile.c
+++ b/source3/lib/sendfile.c
@@ -96,7 +96,7 @@ ssize_t sys_sendfile(int tofd, int fromfd, const DATA_BLOB *header, off_t offset
 
 ssize_t sys_sendfile_native(int tofd, int fromfd, off_t offset, size_t count, struct iovec *hv)
 {
-	ssize_t nwritten;
+	ssize_t nwritten = 0;
 	int total = 0;
 
 	/*


### PR DESCRIPTION
    Use poll() to emulate a blocking sendfile().

    This avoids spinning on EAGAIN/EWOULDBLOCK under Linux implementation,
    which greatly reduces CPU usage.

(https://lists.samba.org/archive/samba/2013-September/175838.html)

    This fixes FreeBSD/Darwin implementation, which under most cases did
    not work, it would break early when nwritten == 0.  Which would happen
    anytime it spun on EAGAIN writing 0 bytes.

(https://forums.freebsd.org/threads/55017/)
