### PR TITLE
autobuild.py: adjust 278c92126 to fix submodule retval

### DIFF
--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -455,7 +455,7 @@ class buildlist(object):
 def cleanup():
     if options.nocleanup:
         return
-    run_cmd("stat %s" % test_tmpdir, show=True)
+    run_cmd("stat %s || true" % test_tmpdir, show=True)
     run_cmd("stat %s" % testbase, show=True)
     do_print("Cleaning up ....")
     for d in cleanup_list:


### PR DESCRIPTION
commit 278c921 added a 'stat' check on test_tmpdir in cleanup(), but
that location (which is assigned to be a subdir of testbase) does not
necessarily exist -- more specifically, does NOT exist on ldb, talloc,
replace, and tevent.  Making the call to stat on test_tmpdir be non-fatal
allows the cleanup to finish and a successful return value on the
autobuild run.