### PR TITLE
s3:lib/messages: Don't call sec_init() too late

### DIFF
--- a/source3/lib/messages.c
+++ b/source3/lib/messages.c
@@ -247,6 +247,8 @@ static NTSTATUS messaging_init_internal(TALLOC_CTX *mem_ctx,
 	const char *priv_path;
 	bool ok;
 
+	sec_init();
+
 	lck_path = lock_path("msg.lock");
 	if (lck_path == NULL) {
 		return NT_STATUS_NO_MEMORY;
@@ -290,8 +292,6 @@ static NTSTATUS messaging_init_internal(TALLOC_CTX *mem_ctx,
 	};
 
 	ctx->event_ctx = ev;
-
-	sec_init();
 
 	ctx->msg_dgm_ref = messaging_dgm_ref(ctx,
 					     ctx->event_ctx,


### PR DESCRIPTION
Ensure that `sec_initial_uid()` returns the correct value by calling `sec_init()` first.  Without this change, the `sec_initial_uid()` calls in question would always return 0, so things go wrong when the initial UID isn't 0:

    $ smbcontrol smbd reload-config
    could not init messaging context