### PR TITLE
Support Windows SMB caller allocation units in statvfs f_bavail

### DIFF
--- a/source3/libsmb/libsmb_stat.c
+++ b/source3/libsmb/libsmb_stat.c
@@ -420,6 +420,8 @@ SMBC_fstatvfs_ctx(SMBCCTX *context,
                                 (fsblkcnt_t) total_allocation_units;
                         st->f_bfree =
                                 (fsblkcnt_t) actual_allocation_units;
+                        st->f_bavail =
+                                (fsblkcnt_t) caller_allocation_units;
                 }
 
                 flags |= SMBC_VFS_FEATURE_NO_UNIXCIFS;


### PR DESCRIPTION
Signed-off-by: Mark Niggemann <mark.niggemann@ge.com>