### PR TITLE
docs-xml: Sort input file list

### DIFF
--- a/docs-xml/Makefile
+++ b/docs-xml/Makefile
@@ -8,7 +8,7 @@ include Makefile.settings
 
 # Docs to build
 MAIN_DOCS = $(patsubst %/index.xml,%,$(wildcard */index.xml))
-MANPAGES = $(wildcard $(MANPAGEDIR)/*.?.xml)
+MANPAGES = $(sort $(wildcard $(MANPAGEDIR)/*.?.xml))
 
 # Lists of files to process
 MANPAGES_PLUCKER = $(patsubst $(MANPAGEDIR)/%.xml,$(PLUCKERDIR)/%.pdb,$(MANPAGES))


### PR DESCRIPTION
because filesystems return entries in undeterministic order
and that ends up in index.xml and influences index.html
preventing reproducible builds of samba packages (e.g. for openSUSE)

See https://reproducible-builds.org/ for why this matters

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>