### PR TITLE
waf: disable-python - fix talloc wscript if bundling disabled

### DIFF
--- a/lib/talloc/wscript
+++ b/lib/talloc/wscript
@@ -74,18 +74,21 @@ def configure(conf):
                                      implied_deps='replace'):
             conf.define('USING_SYSTEM_TALLOC', 1)
 
-        using_system_pytalloc_util = True
-        if not conf.CHECK_BUNDLED_SYSTEM_PKG('pytalloc-util', minversion=VERSION,
-                                             implied_deps='talloc replace'):
+        if conf.env.disable_python:
             using_system_pytalloc_util = False
-
-        # We need to get a pytalloc-util for all the python versions
-        # we are building for
-        if conf.env['EXTRA_PYTHON']:
-            name = 'pytalloc-util' + conf.all_envs['extrapython']['PYTHON_SO_ABI_FLAG']
-            if not conf.CHECK_BUNDLED_SYSTEM_PKG(name, minversion=VERSION,
+        else:
+            using_system_pytalloc_util = True
+            if not conf.CHECK_BUNDLED_SYSTEM_PKG('pytalloc-util', minversion=VERSION,
                                                  implied_deps='talloc replace'):
                 using_system_pytalloc_util = False
+
+            # We need to get a pytalloc-util for all the python versions
+            # we are building for
+            if conf.env['EXTRA_PYTHON']:
+                name = 'pytalloc-util' + conf.all_envs['extrapython']['PYTHON_SO_ABI_FLAG']
+                if not conf.CHECK_BUNDLED_SYSTEM_PKG(name, minversion=VERSION,
+                                                     implied_deps='talloc replace'):
+                    using_system_pytalloc_util = False
 
         if using_system_pytalloc_util:
             conf.define('USING_SYSTEM_PYTALLOC_UTIL', 1)


### PR DESCRIPTION
The pytalloc-util dependency logic in lib/talloc/wscript on a
standalone build checks for pytalloc-util in a manner that will
fail if bundling is disabled, this causes issues on
--disable-python builds of ldb, tevent, and samba.

This patch restructures the logic to skip checks if python
is disabled, instead just setting the temporary state variable
'using_system_pytalloc_util' to False

Successfully tested patch on ldb-1.1.31 and above, tevent-0.9.33,
and samba-4.7_rc3