### PR TITLE
Default ./configure to have regedit build as false

### DIFF
--- a/source3/wscript
+++ b/source3/wscript
@@ -59,7 +59,7 @@ def set_options(opt):
 
     opt.SAMBA3_ADD_OPTION('cluster-support', default=False)
 
-    opt.SAMBA3_ADD_OPTION('regedit', default=None)
+    opt.SAMBA3_ADD_OPTION('regedit', default=False)
 
     opt.SAMBA3_ADD_OPTION('fake-kaserver',
                           help=("Include AFS fake-kaserver support"), default=False)


### PR DESCRIPTION
TL;DR; Don't accept my pull request.
Having in mind you have --with-regedit and no --without-regedit option it would make more sense to have     opt.SAMBA3_ADD_OPTION('regedit', default=False) rather than default=None and then set it to True.
Having in mind the following code as well:
    conf.env.build_regedit = False
    if not Options.options.with_regedit == False:
        conf.PROCESS_SEPARATE_RULE('system_ncurses')
        if conf.CONFIG_SET('HAVE_NCURSES'):
            conf.env.build_regedit = True