### PR TITLE
s3:popt_common: fix popt_common_credentials_set_ignore_missing_conf.

### DIFF
--- a/source3/lib/popt_common.c
+++ b/source3/lib/popt_common.c
@@ -237,7 +237,7 @@ static bool popt_common_credentials_delay_post;
 
 void popt_common_credentials_set_ignore_missing_conf(void)
 {
-	popt_common_credentials_delay_post = true;
+	popt_common_credentials_ignore_missing_conf = true;
 }
 
 void popt_common_credentials_set_delay_post(void)


### PR DESCRIPTION
Set the correct flag in popt_common_credentials_set_ignore_missing_conf() for actually ignoring a missing configuration file.

Signed-off-by: Peter Gale <peter.gale@sophos.com>