### PR TITLE
Fix compilation errors for V4-6-stable

### DIFF
--- a/buildtools/wafsamba/generic_cc.py
+++ b/buildtools/wafsamba/generic_cc.py
@@ -25,6 +25,18 @@ def find_generic_cc(conf):
     v['CC_NAME'] = 'generic'
 
 @conftest
+def find_host_cc(conf):
+    v = conf.env
+    hcc = None
+    if v['HOSTCC']: hcc = v['HOSTCC']
+    elif 'HOSTCC' in conf.environ: hcc = conf.environ['HOSTCC']
+    if not hcc: hcc = conf.find_program('cc', var='HOSTCC')
+    if not hcc: conf.fatal('host_cc was not found, maybe --hostcc is not specified')
+    hcc = conf.cmd_to_list(hcc)
+    v['HOSTCC']  = hcc
+    v['HOSTCC_NAME'] = 'host'
+
+@conftest
 def generic_cc_common_flags(conf):
     v = conf.env
 
@@ -34,6 +46,7 @@ def generic_cc_common_flags(conf):
 
     # linker
     if not v['LINK_CC']: v['LINK_CC'] = v['CC']
+    if not v['LINK_HOSTCC']: v['LINK_HOSTCC'] = v['HOSTCC']
     v['CCLNK_SRC_F']         = ''
     v['CCLNK_TGT_F']         = ['-o', '']
 
@@ -61,6 +74,7 @@ def generic_cc_common_flags(conf):
 
 detect = '''
 find_generic_cc
+find_host_cc
 find_cpp
 find_ar
 generic_cc_common_flags

--- a/buildtools/wafsamba/samba_autoconf.py
+++ b/buildtools/wafsamba/samba_autoconf.py
@@ -836,13 +836,18 @@ def CURRENT_CFLAGS(bld, target, cflags, allow_warnings=False, hide_symbols=False
 
 @conf
 def CHECK_CC_ENV(conf):
-    """trim whitespaces from 'CC'.
+    """trim whitespaces from 'CC' and 'HOSTCC'.
     The build farm sometimes puts a space at the start"""
     if os.environ.get('CC'):
         conf.env.CC = TO_LIST(os.environ.get('CC'))
         if len(conf.env.CC) == 1:
             # make for nicer logs if just a single command
             conf.env.CC = conf.env.CC[0]
+    if os.environ.get('HOSTCC'):
+        conf.env.HOSTCC = TO_LIST(os.environ.get('HOSTCC'))
+        if len(conf.env.HOSTCC) == 1:
+            # make for nicer logs if just a single command
+            conf.env.HOSTCC = conf.env.HOSTCC[0]
 
 
 @conf

--- a/buildtools/wafsamba/samba_deps.py
+++ b/buildtools/wafsamba/samba_deps.py
@@ -225,7 +225,12 @@ def add_init_functions(self):
     sentinel = getattr(self, 'init_function_sentinel', 'NULL')
 
     targets    = LOCAL_CACHE(bld, 'TARGET_TYPE')
-    cflags = getattr(self, 'samba_cflags', [])[:]
+    tmp_cflags = getattr(self, 'samba_cflags', [])[:]
+    if tmp_cflags is None:
+        cflags = tmp_cflags
+    else:
+        cflags = []
+        cflags.extend(tmp_cflags)
 
     if modules == []:
         sname = sname.replace('-','_')

--- a/buildtools/wafsamba/samba_optimisation.py
+++ b/buildtools/wafsamba/samba_optimisation.py
@@ -11,7 +11,7 @@ import Build, Utils, Node
 from TaskGen import feature, after, before
 import preproc
 
-@feature('c', 'cc', 'cxx')
+@feature('c', 'cc', 'hostcc', 'cxx')
 @after('apply_type_vars', 'apply_lib_vars', 'apply_core')
 def apply_incpaths(self):
     lst = []
@@ -59,7 +59,7 @@ def apply_incpaths(self):
         if node:
             self.env.append_value('INC_PATHS', node)
 
-@feature('c', 'cc')
+@feature('c', 'cc', 'hostcc')
 @after('apply_incpaths')
 def apply_obj_vars_cc(self):
     """after apply_incpaths for INC_PATHS"""
@@ -187,7 +187,7 @@ def shared_ancestors(self):
         return ret
 TaskGen.task_gen.shared_ancestors = shared_ancestors
 
-@feature('c', 'cc', 'cxx')
+@feature('c', 'cc', 'hostcc', 'cxx')
 @after('apply_link', 'init_cc', 'init_cxx', 'apply_core')
 def apply_lib_vars(self):
     """after apply_link because of 'link_task'

--- a/buildtools/wafsamba/samba_utils.py
+++ b/buildtools/wafsamba/samba_utils.py
@@ -126,7 +126,7 @@ def ADD_COMMAND(opt, name, function):
 Options.Handler.ADD_COMMAND = ADD_COMMAND
 
 
-@feature('c', 'cc', 'cshlib', 'cprogram')
+@feature('c', 'cc', 'hostcc', 'cshlib', 'cprogram', 'host_cprogram')
 @before('apply_core','exec_rule')
 def process_depends_on(self):
     '''The new depends_on attribute for build rules
@@ -647,7 +647,7 @@ def AD_DC_BUILD_IS_ENABLED(self):
 
 Build.BuildContext.AD_DC_BUILD_IS_ENABLED = AD_DC_BUILD_IS_ENABLED
 
-@feature('cprogram', 'cshlib', 'cstaticlib')
+@feature('cprogram', 'host_cprogram', 'cshlib', 'cstaticlib')
 @after('apply_lib_vars')
 @before('apply_obj_vars')
 def samba_before_apply_obj_vars(self):

--- a/buildtools/wafsamba/wafsamba.py
+++ b/buildtools/wafsamba/wafsamba.py
@@ -945,6 +945,7 @@ def link_display(self):
     fname = self.outputs[0].bldpath(self.env)
     return progress_display(self, 'Linking', fname)
 Task.TaskBase.classes['cc_link'].display = link_display
+Task.TaskBase.classes['hostcc_link'].display = link_display
 
 def samba_display(self):
     if Options.options.progress_bar != 0:

--- a/lib/replace/wscript
+++ b/lib/replace/wscript
@@ -71,7 +71,7 @@ def configure(conf):
     conf.CHECK_HEADERS('sys/fileio.h sys/filesys.h sys/dustat.h sys/sysmacros.h')
     conf.CHECK_HEADERS('xfs/libxfs.h netgroup.h')
 
-    conf.CHECK_CODE('', headers='rpc/rpc.h rpcsvc/yp_prot.h', define='HAVE_RPCSVC_YP_PROT_H')
+    conf.CHECK_HEADERS('rpc/rpc.h rpcsvc/yp_prot.h')
 
     conf.CHECK_HEADERS('valgrind.h valgrind/valgrind.h valgrind/memcheck.h')
     conf.CHECK_HEADERS('nss_common.h nsswitch.h ns_api.h')

--- a/lib/resolv_wrapper/resolv_wrapper.c
+++ b/lib/resolv_wrapper/resolv_wrapper.c
@@ -350,7 +350,11 @@ static ssize_t rwrap_fake_header(uint8_t **header_blob, size_t remaining,
 	memset(hb, 0, NS_HFIXEDSZ);
 
 	h = (HEADER *) hb;
+#ifdef HAVE_RES_RANDOMID
 	h->id = res_randomid();		/* random query ID */
+#else /* HAVE_RES_RANDOMID */
+	h->id = (0xffff & getpid());		/* random query ID */
+#endif /* HAVE_RES_RANDOMID */
 	h->qr = 1;			/* response flag */
 	h->rd = 1;			/* recursion desired */
 	h->ra = 1;			/* recursion available */

--- a/lib/resolv_wrapper/wscript
+++ b/lib/resolv_wrapper/wscript
@@ -57,6 +57,10 @@ def configure(conf):
                                     headers='resolv.h',
                                     define='HAVE_RESOLV_IPV6_NSADDRS')
 
+        conf.CHECK_FUNCS_IN('res_randomid', 'resolv')
+        if conf.CONFIG_SET('HAVE_RES_RANDOMID'):
+            conf.DEFINE('HAVE_RES_RANDOMID_IN_LIBRESOLV', 1)
+
         conf.CHECK_FUNCS_IN('res_ninit', 'resolv')
         if conf.CONFIG_SET('HAVE_RES_NINIT'):
             conf.DEFINE('HAVE_RES_NINIT_IN_LIBRESOLV', 1)

--- a/nsswitch/winbind_nss.h
+++ b/nsswitch/winbind_nss.h
@@ -73,4 +73,12 @@ typedef enum
 
 #endif
 
+#ifndef NETDB_INTERNAL
+#define NETDB_INTERNAL -1 /* See errno. */
+#endif  /* NETDB_INTERNAL */
+
+#ifndef NETDB_SUCCESS
+#define NETDB_SUCCESS 0 /* No problem. */
+#endif  /* NETDB_SUCCESS */
+
 #endif /* _NSSWITCH_NSS_H */

--- a/source4/heimdal_build/wscript_build
+++ b/source4/heimdal_build/wscript_build
@@ -276,8 +276,13 @@ def HEIMDAL_SUBSYSTEM(modname, source,
 
     bld.set_group(group)
 
+    if bld.env.CROSS_COMPILE and use_hostcc:
+        features = 'hostcc'
+    else:
+        features = 'c'
+
     return bld(
-        features       = 'c',
+        features       = features,
         source         = source,
         target         = modname,
         samba_cflags   = CURRENT_CFLAGS(bld, modname, cflags, allow_warnings=True),
@@ -306,7 +311,10 @@ def HEIMDAL_BINARY(binname, source,
     if not SET_TARGET_TYPE(bld, binname, 'BINARY'):
         return
 
-    features = 'c cprogram symlink_bin install_bin'
+    if bld.env.CROSS_COMPILE and use_hostcc:
+        features = 'hostcc host_cprogram symlink_bin install_bin'
+    else:
+        features = 'c cprogram symlink_bin install_bin'
 
     obj_target = binname + '.objlist'
 
@@ -342,7 +350,8 @@ def HEIMDAL_BINARY(binname, source,
         local_include  = True,
         top            = True,
         install_path   = None,
-        samba_install  = install
+        samba_install  = install,
+        samba_use_hostcc = use_hostcc
         )
 
 

--- a/source4/torture/local/nss_tests.c
+++ b/source4/torture/local/nss_tests.c
@@ -346,6 +346,7 @@ static bool test_enum_r_passwd(struct torture_context *tctx,
 	torture_comment(tctx, "Testing setpwent\n");
 	setpwent();
 
+#if defined(HAVE_GETPWENT_R)
 	while (1) {
 		torture_comment(tctx, "Testing getpwent_r\n");
 
@@ -368,6 +369,9 @@ static bool test_enum_r_passwd(struct torture_context *tctx,
 			num_pwd++;
 		}
 	}
+#else /* defined(HAVE_GETPWENT_R) */
+	torture_comment(tctx, "getpwent_r not defined\n");
+#endif /* defined(HAVE_GETPWENT_R) */
 
 	torture_comment(tctx, "Testing endpwent\n");
 	endpwent();
@@ -544,6 +548,7 @@ static bool test_enum_r_group(struct torture_context *tctx,
 	torture_comment(tctx, "Testing setgrent\n");
 	setgrent();
 
+#if defined(HAVE_GETGRENT_R)
 	while (1) {
 		torture_comment(tctx, "Testing getgrent_r\n");
 
@@ -566,6 +571,9 @@ static bool test_enum_r_group(struct torture_context *tctx,
 			num_grp++;
 		}
 	}
+#else /* defined(HAVE_GETGRENT_R) */
+	torture_comment(tctx, "getgrent_r not defined\n");
+#endif /* defined(HAVE_GETGRENT_R) */
 
 	torture_comment(tctx, "Testing endgrent\n");
 	endgrent();

--- a/third_party/waf/wafadmin/3rdparty/batched_cc.py
+++ b/third_party/waf/wafadmin/3rdparty/batched_cc.py
@@ -40,7 +40,7 @@ class batch_task(Task.Task):
 	color = 'RED'
 
 	after = 'cc cxx'
-	before = 'cc_link cxx_link static_link'
+	before = 'cc_link hostcc_link cxx_link static_link'
 
 	def __str__(self):
 		return '(batch compilation for %d slaves)\n' % len(self.slaves)
@@ -147,7 +147,7 @@ cxx_hook = wrap(cxx.cxx_hook)
 extension(cxx.EXT_CXX)(cxx_hook)
 
 
-@feature('cprogram', 'cshlib', 'cstaticlib')
+@feature('cprogram', 'host_cprogram', 'cshlib', 'cstaticlib')
 @after('apply_link')
 def link_after_masters(self):
 	if getattr(self, 'allmasters', None):

--- a/third_party/waf/wafadmin/3rdparty/gccdeps.py
+++ b/third_party/waf/wafadmin/3rdparty/gccdeps.py
@@ -15,11 +15,13 @@ lock = threading.Lock()
 
 preprocessor_flag = '-MD'
 
-@feature('cc', 'c')
+@feature('hostcc', 'cc', 'c')
 @before('apply_core')
 def add_mmd_cc(self):
 	if self.env.get_flat('CCFLAGS').find(preprocessor_flag) < 0:
 		self.env.append_value('CCFLAGS', preprocessor_flag)
+	if self.env.get_flat('HOST_CCFLAGS').find(preprocessor_flag) < 0:
+		self.env.append_value('HOST_CCFLAGS', preprocessor_flag)
 
 @feature('cxx')
 @before('apply_core')
@@ -116,7 +118,7 @@ def sig_implicit_deps(self):
 	except Utils.WafError:
 		return Constants.SIG_NIL
 
-for name in 'cc cxx'.split():
+for name in 'hostcc cc cxx'.split():
 	try:
 		cls = Task.TaskBase.classes[name]
 	except KeyError:

--- a/third_party/waf/wafadmin/3rdparty/valadoc.py
+++ b/third_party/waf/wafadmin/3rdparty/valadoc.py
@@ -14,7 +14,7 @@ class valadoc_task(Task.Task):
 
   vars = ['VALADOC', 'VALADOCFLAGS']
   color = 'BLUE'
-  after = 'cxx_link cc_link'
+  after = 'cxx_link hostcc_link cc_link'
   quiet = True
 
   output_dir = ''

--- a/third_party/waf/wafadmin/Tools/config_c.py
+++ b/third_party/waf/wafadmin/Tools/config_c.py
@@ -734,6 +734,8 @@ def find_cpp(conf):
 def cc_add_flags(conf):
 	conf.add_os_flags('CFLAGS', 'CCFLAGS')
 	conf.add_os_flags('CPPFLAGS')
+	conf.add_os_flags('HOST_CCFLAGS')
+	conf.add_os_flags('HOST_CPPFLAGS')
 
 @conftest
 def cxx_add_flags(conf):
@@ -744,6 +746,8 @@ def cxx_add_flags(conf):
 def link_add_flags(conf):
 	conf.add_os_flags('LINKFLAGS')
 	conf.add_os_flags('LDFLAGS', 'LINKFLAGS')
+	conf.add_os_flags('HOST_LINKFLAGS')
+	conf.add_os_flags('HOST_LDFLAGS', 'HOST_LINKFLAGS')
 
 @conftest
 def cc_load_tools(conf):

--- a/third_party/waf/wafadmin/Tools/gcc.py
+++ b/third_party/waf/wafadmin/Tools/gcc.py
@@ -18,6 +18,14 @@ def find_gcc(conf):
 	conf.env.CC      = cc
 
 @conftest
+def find_host_gcc(conf):
+	hcc = conf.find_program(['gcc', 'cc'], var='HOSTCC', mandatory=True)
+	hcc = conf.cmd_to_list(hcc)
+	ccroot.get_cc_version(conf, hcc, gcc=True)
+	conf.env.HOSTCC_NAME = 'host gcc'
+	conf.env.HOSTCC      = hcc
+
+@conftest
 def gcc_common_flags(conf):
 	v = conf.env
 
@@ -33,6 +41,7 @@ def gcc_common_flags(conf):
 
 	# linker
 	if not v['LINK_CC']: v['LINK_CC'] = v['CC']
+	if not v['LINK_HOSTCC']: v['LINK_HOSTCC'] = v['HOSTCC']
 	v['CCLNK_SRC_F']         = ''
 	v['CCLNK_TGT_F']         = ['-o', ''] # shell hack for -MD
 
@@ -129,6 +138,7 @@ def gcc_modifier_platform(conf):
 
 def detect(conf):
 	conf.find_gcc()
+	conf.find_host_gcc()
 	conf.find_cpp()
 	conf.find_ar()
 	conf.gcc_common_flags()

--- a/third_party/waf/wafadmin/Tools/intltool.py
+++ b/third_party/waf/wafadmin/Tools/intltool.py
@@ -91,7 +91,7 @@ def apply_intltool_po(self):
 Task.simple_task_type('po', '${POCOM} -o ${TGT} ${SRC}', color='BLUE', shell=False)
 Task.simple_task_type('intltool',
 	'${INTLTOOL} ${INTLFLAGS} ${INTLCACHE} ${INTLPODIR} ${SRC} ${TGT}',
-	color='BLUE', after="cc_link cxx_link", shell=False)
+	color='BLUE', after="cc_link hostcc_link cxx_link", shell=False)
 
 def detect(conf):
 	pocom = conf.find_program('msgfmt')

--- a/third_party/waf/wafadmin/Tools/libtool.py
+++ b/third_party/waf/wafadmin/Tools/libtool.py
@@ -112,7 +112,7 @@ def apply_libtool(self):
 				continue
 			self.env.append_unique('LINKFLAGS', v)
 
-Task.task_type_from_func('fakelibtool', vars=fakelibtool_vardeps, func=fakelibtool_build, color='BLUE', after="cc_link cxx_link static_link")
+Task.task_type_from_func('fakelibtool', vars=fakelibtool_vardeps, func=fakelibtool_build, color='BLUE', after="cc_link hostcc_link cxx_link static_link")
 
 class libtool_la_file:
 	def __init__ (self, la_filename):


### PR DESCRIPTION
This pull request fixes lots of compilation errors when building samba-4-6 on [LEDE/OpenWRT,](https://github.com/lede-project/source) and the target sdk use musl or glibc as its basic c library.
Since the samba-4-6 build always fail when cross-compile, thus I added 'hostcc' feature for waf build system. Please feel free to point out my mistake and misunderstand, thanks :-).

The commit also fixes below bug from 4-4-3 version, :-)
https://bugzilla.samba.org/show_bug.cgi?id=11891