### PR TITLE
libwbclient: skip duplicate primary group in returned sids array

### DIFF
--- a/nsswitch/libwbclient/wbc_pam.c
+++ b/nsswitch/libwbclient/wbc_pam.c
@@ -187,6 +187,10 @@ static wbcErr wbc_create_auth_info(const struct winbindd_response *resp,
 			BAIL_ON_WBC_ERROR(wbc_status);
 		}
 
+		/* Skip primary group, already added */
+		if (rid == resp->data.auth.info3.group_rid)
+			continue;
+
 		if (!sid_attr_compose(&i->sids[sn], &domain_sid,
 				      rid, attrs)) {
 			wbc_status = WBC_ERR_INVALID_SID;


### PR DESCRIPTION
When calling wbcCtxAuthenticateUser, the primary group currently
being referenced twice in returned wbcAuthUserInfo.sids array.
Fix this by skipping the second addition.

Signed-off-by: Isaac Boukris <iboukris@gmail.com>