### PR TITLE
Update libsmb_server.c

### DIFF
--- a/source3/libsmb/libsmb_server.c
+++ b/source3/libsmb/libsmb_server.c
@@ -562,8 +562,8 @@ SMBC_server_internal(TALLOC_CTX *ctx,
 
 	status = cli_tree_connect_creds(c, share, "?????", creds);
 	if (!NT_STATUS_IS_OK(status)) {
-		errno = map_errno_from_nt_status(status);
 		cli_shutdown(c);
+		errno = map_errno_from_nt_status(status);
 		return NULL;
 	}
 


### PR DESCRIPTION
cli_shutdown() overwrites the wanted errno returned from ``status = cli_tree_connect_creds(c, share, "?????", creds);``

This is likely the bug reported here https://bugzilla.samba.org/show_bug.cgi?id=13050

As I was having experiencing the same behavior when using samba bindings for python.