### PR TITLE
Conditionally disable macOS incompatible tests

### DIFF
--- a/source4/torture/local/nss_tests.c
+++ b/source4/torture/local/nss_tests.c
@@ -346,6 +346,7 @@ static bool test_enum_r_passwd(struct torture_context *tctx,
 	torture_comment(tctx, "Testing setpwent\n");
 	setpwent();
 
+#ifdef HAVE_GETPWENT_R /* getpwent_r not supported on macOS */
 	while (1) {
 		torture_comment(tctx, "Testing getpwent_r\n");
 
@@ -368,6 +369,7 @@ static bool test_enum_r_passwd(struct torture_context *tctx,
 			num_pwd++;
 		}
 	}
+#endif /* getpwent_r not supported on macOS */
 
 	torture_comment(tctx, "Testing endpwent\n");
 	endpwent();
@@ -544,6 +546,7 @@ static bool test_enum_r_group(struct torture_context *tctx,
 	torture_comment(tctx, "Testing setgrent\n");
 	setgrent();
 
+#ifdef HAVE_GETGRENT_R /* getgrent_r not supported on macOS */
 	while (1) {
 		torture_comment(tctx, "Testing getgrent_r\n");
 
@@ -566,6 +569,7 @@ static bool test_enum_r_group(struct torture_context *tctx,
 			num_grp++;
 		}
 	}
+#endif /* getgrent_r not supported on macOS */
 
 	torture_comment(tctx, "Testing endgrent\n");
 	endgrent();


### PR DESCRIPTION
Symbols _getgrent_r and _getpwent_r in source4/torture/local/nss_tests.c are undefined in macOS. It seems that checking HAVE_GETGRENT_R and HAVE_GETPWENT_R and conditionally disabling those tests as suggested by hirochachacha in the referenced bug allows samba on both `master` and `samba-4.7.1` to build properly on macOS/darwin.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=11984

```
Linking default/source4/torture/smbtorture
clang: warning: argument unused during compilation: '-pie'
Undefined symbols for architecture x86_64:
  "_getgrent_r", referenced from:
      _test_enum_r_group in nss_tests_1.o
  "_getpwent_r", referenced from:
      _test_enum_r_passwd in nss_tests_1.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Signed-off-by: Will Haley <willhy@gmail.com>