### PR TITLE
Try to extrapolate PYTHON_SO_ABI_FLAG  from the SOABI Python config variable

### DIFF
--- a/buildtools/wafsamba/samba_python.py
+++ b/buildtools/wafsamba/samba_python.py
@@ -76,17 +76,31 @@ def SAMBA_CHECK_PYTHON_HEADERS(conf, mandatory=True):
 
 def _check_python_headers(conf, mandatory):
     try:
+        from python import _get_python_variables
         Configure.ConfigurationError
         conf.check_python_headers(mandatory=mandatory)
+        conf.env['PYTHON_SO_ABI'] = _get_python_variables(
+            conf.env['PYTHON'],
+            ["get_config_var('SOABI') or ''"],
+            ['from distutils.sysconfig import get_config_var']
+        )[0]
     except Configure.ConfigurationError:
         if mandatory:
              raise
 
     if conf.env['PYTHON_VERSION'] > '3':
-        abi_pattern = os.path.splitext(conf.env['pyext_PATTERN'])[0]
-        conf.env['PYTHON_SO_ABI_FLAG'] = abi_pattern % ''
+        override_PYTHON3_SO_ABI_FLAG = os.getenv('PYTHON3_SO_ABI_FLAG', None)
+        if override_PYTHON3_SO_ABI_FLAG is not None:
+            conf.env['PYTHON_SO_ABI_FLAG'] = override_PYTHON3_SO_ABI_FLAG
+        if not conf.env['PYTHON_SO_ABI_FLAG']:
+            if conf.env['PYTHON_SO_ABI']:
+                conf.env['PYTHON_SO_ABI_FLAG'] = '.'+conf.env['PYTHON_SO_ABI']
+            else:
+                abi_pattern = os.path.splitext(conf.env['pyext_PATTERN'])[0]
+                conf.env['PYTHON_SO_ABI_FLAG'] = abi_pattern % ''
     else:
         conf.env['PYTHON_SO_ABI_FLAG'] = ''
+
     conf.env['PYTHON_LIBNAME_SO_ABI_FLAG'] = (
         conf.env['PYTHON_SO_ABI_FLAG'].replace('_', '-'))
 


### PR DESCRIPTION
Python3 configuration handling (ab)uses "SO" configuration variable to
extract SO ABI extension. It happens to work on Linux as this variable
contains not only binary module extension, but also ABI part, like in
.cpython-34m.so or in .cpython-35m-x86_64-linux-gnu.so. In FreeBSD this
variable contains only .so. The SO ABI extension in fact, is stored in
the "SOABI" variable and should be taken from there directly, without
relying on the content of SO variable. For Linux it contains
"cpython-34m" and "cpython-35m-x86_64-linux-gnu" respectivelly, for
FreeBSD it is "cpython-36m".

We are trying to set PYTHON_SO_ABI_FLAG based on the value of SOABI and
only if it's not available - fall back to the old method of guessing it
from the SO configuration variable.