### PR TITLE
Fix crackcheck Makefile to allow building on Ubuntu

### DIFF
--- a/examples/auth/crackcheck/Makefile
+++ b/examples/auth/crackcheck/Makefile
@@ -15,7 +15,7 @@ OBJS = crackcheck.o
 LIBS = -lcrack
 
 crackcheck: $(OBJS)
-	$(CC) $(CFLAGS) $(LIBS) -o crackcheck $(OBJS)
+	$(CC) $(CFLAGS) -o crackcheck $(OBJS) $(LIBS)
 
 clean:
 	rm -f core *.o crackcheck

--- a/examples/auth/crackcheck/crackcheck.c
+++ b/examples/auth/crackcheck/crackcheck.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <crack.h>
+#include <unistd.h>
 
 void usage(char *command) {
 	char *c, *comm;


### PR DESCRIPTION
This patch fixes the following failure when attempting to build crackcheck under Ubuntu 16.04:

~~~
# make
gcc  -O2   -c -o crackcheck.o crackcheck.c
crackcheck.c: In function ‘main’:
crackcheck.c:91:15: warning: implicit declaration of function ‘getopt’ [-Wimplicit-function-declaratio
  while ( (c = getopt(argc, argv, "d:cs")) != EOF){
               ^
gcc  -O2 -lcrack -o crackcheck crackcheck.o
crackcheck.o: In function `main':
crackcheck.c:(.text.startup+0xee): undefined reference to `FascistCheck'
collect2: error: ld returned 1 exit status
Makefile:18: recipe for target 'crackcheck' failed
make: *** [crackcheck] Error 1
~~~

It just needs the `-lcrack` option to be moved to the end of the command line. Also adds `#include <unistd.h>` to silence the getopt warning.