### PR TITLE
Change order of flags in Makefile so that crackcheck builds under Ubuntu

### DIFF
--- a/examples/auth/crackcheck/Makefile
+++ b/examples/auth/crackcheck/Makefile
@@ -15,7 +15,7 @@ OBJS = crackcheck.o
 LIBS = -lcrack
 
 crackcheck: $(OBJS)
-	$(CC) $(CFLAGS) $(LIBS) -o crackcheck $(OBJS)
+	$(CC) $(CFLAGS) -o crackcheck $(OBJS) $(LIBS)
 
 clean:
 	rm -f core *.o crackcheck


### PR DESCRIPTION
Fixes build problem under Ubuntu

~~~
# make
gcc  -O2   -c -o crackcheck.o crackcheck.c
...
gcc  -O2 -lcrack -o crackcheck crackcheck.o
crackcheck.o: In function `main':
crackcheck.c:(.text.startup+0xee): undefined reference to `FascistCheck'
collect2: error: ld returned 1 exit status
Makefile:18: recipe for target 'crackcheck' failed
make: *** [crackcheck] Error 1
~~~
