### PR TITLE
Add #include <unistd.h> to provide prototype for getopt()

### DIFF
--- a/examples/auth/crackcheck/crackcheck.c
+++ b/examples/auth/crackcheck/crackcheck.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <crack.h>
+#include <unistd.h>
 
 void usage(char *command) {
 	char *c, *comm;


### PR DESCRIPTION
Fixes warning when building crackcheck:

~~~
# make
gcc  -O2   -c -o crackcheck.o crackcheck.c
crackcheck.c: In function ‘main’:
crackcheck.c:91:15: warning: implicit declaration of function ‘getopt’ [-Wimplicit-function-declaratio
  while ( (c = getopt(argc, argv, "d:cs")) != EOF){
               ^
~~~
