### PR TITLE
systemd: syslog.target is obsolete

### DIFF
--- a/packaging/systemd/nmb.service
+++ b/packaging/systemd/nmb.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Samba NMB Daemon
 Wants=network-online.target
-After=syslog.target network.target network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=notify

--- a/packaging/systemd/samba.service
+++ b/packaging/systemd/samba.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Samba AD Daemon
 Wants=network-online.target
-After=syslog.target network.target network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=notify

--- a/packaging/systemd/smb.service
+++ b/packaging/systemd/smb.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Samba SMB Daemon
-After=syslog.target network.target nmb.service winbind.service
+After=network.target nmb.service winbind.service
 
 [Service]
 Type=notify

--- a/packaging/systemd/winbind.service
+++ b/packaging/systemd/winbind.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Samba Winbind Daemon
-After=syslog.target network.target nmb.service
+After=network.target nmb.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
After=syslog.target is unnecessary by now because syslog is socket-activated and will therefore be started when needed.

Ref: https://lintian.debian.org/tags/systemd-service-file-refers-to-obsolete-target.html

BUG: https://bugzilla.samba.org/show_bug.cgi?id=12402

Signed-off-by: Mathieu Parent <math.parent@gmail.com>