### PR TITLE
Remove build system info (uname -a)

### DIFF
--- a/buildtools/wafsamba/wscript
+++ b/buildtools/wafsamba/wscript
@@ -313,10 +313,6 @@ def configure(conf):
 
     conf.env.GIT_LOCAL_CHANGES = Options.options.GIT_LOCAL_CHANGES
 
-    conf.CHECK_COMMAND(['uname', '-a'],
-                       msg='Checking build system',
-                       define='BUILD_SYSTEM',
-                       on_target=False)
     conf.CHECK_UNAME()
 
     # see if we can compile and run a simple C program

--- a/source4/smbd/server.c
+++ b/source4/smbd/server.c
@@ -323,9 +323,6 @@ static void show_build(void)
 
 	printf("Samba version: %s\n", SAMBA_VERSION_STRING);
 	printf("Build environment:\n");
-#ifdef BUILD_SYSTEM
-	printf("   Build host:  %s\n", BUILD_SYSTEM);
-#endif
 
 	printf("Paths:\n");
 	for (i=0; config_options[i].name; i++) {


### PR DESCRIPTION
Preventing reproducible builds while adding minor benefit.

More information at <https://reproducible-builds.org/>.

Signed-off-by: Mathieu Parent <math.parent@gmail.com>