### PR TITLE
Update the help text for dbcheck

### DIFF
--- a/python/samba/netcmd/dbcheck.py
+++ b/python/samba/netcmd/dbcheck.py
@@ -61,7 +61,7 @@ class cmd_dbcheck(Command):
         Option("--fix", dest="fix", default=False, action='store_true',
                help='Fix any errors found'),
         Option("--yes", action='callback', callback=process_yes,
-               help="don't confirm changes, applies all in a single transaction (requires all changes to succeed)"),
+               help="don't confirm changes individually. Applies all as a single transaction (will not succeed if any errors are found)"),
         Option("--cross-ncs", dest="cross_ncs", default=False, action='store_true',
                help="cross naming context boundaries"),
         Option("-v", "--verbose", dest="verbose", action="store_true", default=False,

--- a/python/samba/netcmd/dbcheck.py
+++ b/python/samba/netcmd/dbcheck.py
@@ -61,7 +61,7 @@ class cmd_dbcheck(Command):
         Option("--fix", dest="fix", default=False, action='store_true',
                help='Fix any errors found'),
         Option("--yes", action='callback', callback=process_yes,
-               help="don't confirm changes, just do them all as a single transaction"),
+               help="don't confirm changes, applies all in a single transaction (requires all changes to succeed)"),
         Option("--cross-ncs", dest="cross_ncs", default=False, action='store_true',
                help="cross naming context boundaries"),
         Option("-v", "--verbose", dest="verbose", action="store_true", default=False,


### PR DESCRIPTION
Update the help text for dbcheck, to make its behaviour clear (in particular with reference to the difference between specifying "--yes" on the command line, and answering "yes"/"all" to each individual question)

Following on from discussion on samba@lists.samba.org mailing list (subject 'samba-tool dbcheck on 4.7.5, after bug 13228')