### PR TITLE
Python3: Bulk tuple exceptions conversion

### DIFF
--- a/python/samba/dbchecker.py
+++ b/python/samba/dbchecker.py
@@ -108,7 +108,8 @@ class dbcheck(object):
                            attrs=["objectSid"])
             dnsadmins_sid = ndr_unpack(security.dom_sid, res[0]["objectSid"][0])
             self.name_map['DnsAdmins'] = str(dnsadmins_sid)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e5:
+            (enum, estr) = e5.args
             if enum != ldb.ERR_NO_SUCH_OBJECT:
                 raise
             pass
@@ -198,7 +199,8 @@ class dbcheck(object):
                 self.compatibleFeatures = res[0]["compatibleFeatures"]
             if "requiredFeatures" in res[0]:
                 self.requiredFeatures = res[0]["requiredFeatures"]
-        except ldb.LdbError as (enum, estr):
+        except ldb.LdbError as e6:
+            (enum, estr) = e6.args
             if enum != ldb.ERR_NO_SUCH_OBJECT:
                 raise
             pass
@@ -253,7 +255,8 @@ class dbcheck(object):
                                          "CN=Deleted Objects\\0ACNF:%s" % str(misc.GUID(guid)))
                     conflict_dn.add_base(nc)
 
-            except ldb.LdbError, (enum, estr):
+            except ldb.LdbError as e2:
+                (enum, estr) = e2.args
                 if enum == ldb.ERR_NO_SUCH_OBJECT:
                     pass
                 else:
@@ -263,7 +266,8 @@ class dbcheck(object):
             if conflict_dn is not None:
                 try:
                     self.samdb.rename(dn, conflict_dn, ["show_deleted:1", "relax:0", "show_recycled:1"])
-                except ldb.LdbError, (enum, estr):
+                except ldb.LdbError as e1:
+                    (enum, estr) = e1.args
                     self.report("Couldn't move old Deleted Objects placeholder: %s to %s: %s" % (dn, conflict_dn, estr))
                     return 1
 
@@ -596,7 +600,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
         try:
             res = self.samdb.search(base=str(dsdb_dn.dn), scope=ldb.SCOPE_BASE,
                                     attrs=[], controls=controls)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e7:
+            (enum, estr) = e7.args
             self.report("unable to find object for DN %s - (%s)" % (dsdb_dn.dn, estr))
             if enum != ldb.ERR_NO_SUCH_OBJECT:
                 raise
@@ -999,7 +1004,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
         try:
             res = self.samdb.search(base=str(dn), scope=ldb.SCOPE_BASE,
                                     attrs=attrs, controls=controls)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e8:
+            (enum, estr) = e8.args
             if enum != ldb.ERR_NO_SUCH_OBJECT:
                 raise
 
@@ -1046,7 +1052,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
                                     controls=["extended_dn:1:1",
                                               "search_options:1:2",
                                               "paged_results:1:1000"])
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e9:
+            (enum, estr) = e9.args
             raise
 
         for r in res:
@@ -1198,7 +1205,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
                                         attrs=attrs, controls=["extended_dn:1:1", "show_recycled:1",
                                                                "reveal_internals:0"
                                         ])
-            except ldb.LdbError, (enum, estr):
+            except ldb.LdbError as e3:
+                (enum, estr) = e3.args
                 if enum != ldb.ERR_NO_SUCH_OBJECT:
                     raise
 
@@ -1924,7 +1932,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
             instancetype |= dsdb.INSTANCE_TYPE_IS_NC_HEAD
             try:
                 self.samdb.search(base=dn.parent(), scope=ldb.SCOPE_BASE, attrs=[], controls=["show_recycled:1"])
-            except ldb.LdbError, (enum, estr):
+            except ldb.LdbError as e4:
+                (enum, estr) = e4.args
                 if enum != ldb.ERR_NO_SUCH_OBJECT:
                     raise
             else:
@@ -1995,7 +2004,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
                                         "reveal_internals:0",
                                     ],
                                     attrs=attrs)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e10:
+            (enum, estr) = e10.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 if self.in_transaction:
                     self.report("ERROR: Object %s disappeared during check" % dn)
@@ -2303,7 +2313,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
             if dn != self.samdb.get_root_basedn() and str(dn.parent()) not in self.dn_set:
                 res = self.samdb.search(base=dn.parent(), scope=ldb.SCOPE_BASE,
                                         controls=["show_recycled:1", "show_deleted:1"])
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e11:
+            (enum, estr) = e11.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 self.err_missing_parent(obj)
                 error_count += 1
@@ -2407,7 +2418,8 @@ newSuperior: %s""" % (str(from_dn), str(to_rdn), str(to_base)))
                     try:
                         res = self.samdb.search(base="<SID=%s>" % sid, scope=ldb.SCOPE_BASE,
                                                 attrs=[])
-                    except ldb.LdbError, (enum, estr):
+                    except ldb.LdbError as e:
+                        (enum, estr) = e.args
                         if enum != ldb.ERR_NO_SUCH_OBJECT:
                             raise
                         res = None

--- a/python/samba/join.py
+++ b/python/samba/join.py
@@ -92,7 +92,8 @@ class dc_join(object):
 
         try:
             ctx.samdb.search(scope=ldb.SCOPE_ONELEVEL, attrs=["dn"])
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e4:
+            (enum, estr) = e4.args
             raise DCJoinException(estr)
 
 
@@ -404,7 +405,8 @@ class dc_join(object):
         '''check if a DN exists'''
         try:
             res = ctx.samdb.search(base=dn, scope=ldb.SCOPE_BASE, attrs=[])
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e5:
+            (enum, estr) = e5.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 return False
             raise
@@ -705,7 +707,8 @@ class dc_join(object):
                                       ctx.acct_pass,
                                       force_change_at_next_login=False,
                                       username=ctx.samname)
-            except ldb.LdbError, (num, _):
+            except ldb.LdbError as e2:
+                (num, _) = e2.args
                 if num != ldb.ERR_UNWILLING_TO_PERFORM:
                     pass
                 ctx.net.set_password(account_name=ctx.samname,
@@ -754,7 +757,8 @@ class dc_join(object):
                                                 samba.dsdb.UF_ACCOUNTDISABLE)
                 try:
                     ctx.samdb.add(msg)
-                except ldb.LdbError, (num, _):
+                except ldb.LdbError as e:
+                    (num, _) = e.args
                     if num != ldb.ERR_ENTRY_ALREADY_EXISTS:
                         raise
 
@@ -770,7 +774,8 @@ class dc_join(object):
                                       ctx.dnspass,
                                       force_change_at_next_login=False,
                                       username=ctx.samname)
-            except ldb.LdbError, (num, _):
+            except ldb.LdbError as e3:
+                (num, _) = e3.args
                 if num != ldb.ERR_UNWILLING_TO_PERFORM:
                     raise
                 ctx.net.set_password(account_name="dns-%s" % ctx.myname,
@@ -965,7 +970,8 @@ class dc_join(object):
                     repl.replicate(ctx.rid_manager_dn, source_dsa_invocation_id,
                                    destination_dsa_guid,
                                    exop=drsuapi.DRSUAPI_EXOP_FSMO_RID_ALLOC)
-                except samba.DsExtendedError, (enum, estr):
+                except samba.DsExtendedError as e1:
+                    (enum, estr) = e1.args
                     if enum == drsuapi.DRSUAPI_EXOP_ERR_FSMO_NOT_OWNER:
                         print "WARNING: Unable to replicate own RID Set, as server %s (the server we joined) is not the RID Master." % ctx.server
                         print "NOTE: This is normal and expected, Samba will be able to create users after it contacts the RID Master at first startup."

--- a/python/samba/kcc/__init__.py
+++ b/python/samba/kcc/__init__.py
@@ -152,7 +152,8 @@ class KCC(object):
                                     self.samdb.get_config_basedn(),
                                     scope=ldb.SCOPE_SUBTREE,
                                     expression="(objectClass=interSiteTransport)")
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e2:
+            (enum, estr) = e2.args
             raise KCCError("Unable to find inter-site transports - (%s)" %
                            estr)
 
@@ -186,7 +187,8 @@ class KCC(object):
                                     self.samdb.get_config_basedn(),
                                     scope=ldb.SCOPE_SUBTREE,
                                     expression="(objectClass=siteLink)")
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e3:
+            (enum, estr) = e3.args
             raise KCCError("Unable to find inter-site siteLinks - (%s)" % estr)
 
         for msg in res:
@@ -249,7 +251,8 @@ class KCC(object):
                                     self.samdb.get_config_basedn(),
                                     scope=ldb.SCOPE_SUBTREE,
                                     expression="(objectClass=site)")
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e4:
+            (enum, estr) = e4.args
             raise KCCError("Unable to find sites - (%s)" % estr)
 
         for msg in res:
@@ -267,7 +270,8 @@ class KCC(object):
         try:
             res = self.samdb.search(base=dn, scope=ldb.SCOPE_BASE,
                                     attrs=["objectGUID"])
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e5:
+            (enum, estr) = e5.args
             DEBUG_FN("Search for dn '%s' [from %s] failed: %s. "
                      "This typically happens in --importldif mode due "
                      "to lack of module support." % (dn, dn_query, estr))
@@ -286,7 +290,8 @@ class KCC(object):
 
                 res = self.samdb.search(base=dn, scope=ldb.SCOPE_BASE,
                                         attrs=["objectGUID"])
-            except ldb.LdbError, (enum, estr):
+            except ldb.LdbError as e:
+                (enum, estr) = e.args
                 raise KCCError("Unable to find my nTDSDSA - (%s)" % estr)
 
         if len(res) != 1:
@@ -326,7 +331,8 @@ class KCC(object):
                                     self.samdb.get_config_basedn(),
                                     scope=ldb.SCOPE_SUBTREE,
                                     expression="(objectClass=crossRef)")
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e6:
+            (enum, estr) = e6.args
             raise KCCError("Unable to find partitions - (%s)" % estr)
 
         for msg in res:
@@ -2479,7 +2485,8 @@ class KCC(object):
                 self.samdb = SamDB(url=dburl,
                                    session_info=system_session(),
                                    credentials=creds, lp=lp)
-            except ldb.LdbError, (num, msg):
+            except ldb.LdbError as e1:
+                (num, msg) = e1.args
                 raise KCCError("Unable to open sam database %s : %s" %
                                (dburl, msg))
 

--- a/python/samba/kcc/kcc_utils.py
+++ b/python/samba/kcc/kcc_utils.py
@@ -83,7 +83,8 @@ class NamingContext(object):
             res = samdb.search(base=self.nc_dnstr,
                                scope=ldb.SCOPE_BASE, attrs=attrs)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e:
+            (enum, estr) = e.args
             raise KCCError("Unable to find naming context (%s) - (%s)" %
                            (self.nc_dnstr, estr))
         msg = res[0]
@@ -301,7 +302,8 @@ class NCReplica(NamingContext):
             res = samdb.search(base=self.nc_dnstr, scope=ldb.SCOPE_BASE,
                                attrs=["repsFrom"])
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e1:
+            (enum, estr) = e1.args
             raise KCCError("Unable to find NC for (%s) - (%s)" %
                            (self.nc_dnstr, estr))
 
@@ -389,7 +391,8 @@ class NCReplica(NamingContext):
             res = samdb.search(base=self.nc_dnstr, scope=ldb.SCOPE_BASE,
                                attrs=["replUpToDateVector"])
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e2:
+            (enum, estr) = e2.args
             raise KCCError("Unable to find NC for (%s) - (%s)" %
                            (self.nc_dnstr, estr))
 
@@ -423,7 +426,8 @@ class NCReplica(NamingContext):
             res = samdb.search(base=self.nc_dnstr, scope=ldb.SCOPE_BASE,
                                attrs=["fSMORoleOwner"])
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e3:
+            (enum, estr) = e3.args
             raise KCCError("Unable to find NC for (%s) - (%s)" %
                            (self.nc_dnstr, estr))
 
@@ -452,7 +456,8 @@ class NCReplica(NamingContext):
             res = samdb.search(base=self.nc_dnstr, scope=ldb.SCOPE_BASE,
                                attrs=["repsTo"])
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e4:
+            (enum, estr) = e4.args
             raise KCCError("Unable to find NC for (%s) - (%s)" %
                            (self.nc_dnstr, estr))
 
@@ -644,7 +649,8 @@ class DirectoryServiceAgent(object):
             res = samdb.search(base=self.dsa_dnstr, scope=ldb.SCOPE_BASE,
                                attrs=attrs)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e5:
+            (enum, estr) = e5.args
             raise KCCError("Unable to find nTDSDSA for (%s) - (%s)" %
                            (self.dsa_dnstr, estr))
 
@@ -705,7 +711,8 @@ class DirectoryServiceAgent(object):
             res = samdb.search(base=self.dsa_dnstr, scope=ldb.SCOPE_BASE,
                                attrs=ncattrs)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e6:
+            (enum, estr) = e6.args
             raise KCCError("Unable to find nTDSDSA NCs for (%s) - (%s)" %
                            (self.dsa_dnstr, estr))
 
@@ -773,7 +780,8 @@ class DirectoryServiceAgent(object):
                                scope=ldb.SCOPE_SUBTREE,
                                expression="(objectClass=nTDSConnection)")
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e7:
+            (enum, estr) = e7.args
             raise KCCError("Unable to find nTDSConnection for (%s) - (%s)" %
                            (self.dsa_dnstr, estr))
 
@@ -951,7 +959,8 @@ class NTDSConnection(object):
             res = samdb.search(base=self.dnstr, scope=ldb.SCOPE_BASE,
                                attrs=attrs)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e8:
+            (enum, estr) = e8.args
             raise KCCError("Unable to find nTDSConnection for (%s) - (%s)" %
                            (self.dnstr, estr))
 
@@ -1001,7 +1010,8 @@ class NTDSConnection(object):
             res = samdb.search(base=tdnstr,
                                scope=ldb.SCOPE_BASE, attrs=attrs)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e9:
+            (enum, estr) = e9.args
             raise KCCError("Unable to find transport (%s) - (%s)" %
                            (tdnstr, estr))
 
@@ -1028,7 +1038,8 @@ class NTDSConnection(object):
 
         try:
             samdb.delete(self.dnstr)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e10:
+            (enum, estr) = e10.args
             raise KCCError("Could not delete nTDSConnection for (%s) - (%s)" %
                            (self.dnstr, estr))
 
@@ -1052,7 +1063,8 @@ class NTDSConnection(object):
             if len(msg) != 0:
                 found = True
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e11:
+            (enum, estr) = e11.args
             if enum != ldb.ERR_NO_SUCH_OBJECT:
                 raise KCCError("Unable to search for (%s) - (%s)" %
                                (self.dnstr, estr))
@@ -1097,7 +1109,8 @@ class NTDSConnection(object):
                                    ldb.FLAG_MOD_ADD, "schedule")
         try:
             samdb.add(m)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e12:
+            (enum, estr) = e12.args
             raise KCCError("Could not add nTDSConnection for (%s) - (%s)" %
                            (self.dnstr, estr))
 
@@ -1120,7 +1133,8 @@ class NTDSConnection(object):
             # of self.dnstr in the database.
             samdb.search(base=self.dnstr, scope=ldb.SCOPE_BASE)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e13:
+            (enum, estr) = e13.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 raise KCCError("nTDSConnection for (%s) doesn't exist!" %
                                self.dnstr)
@@ -1166,7 +1180,8 @@ class NTDSConnection(object):
                 ldb.MessageElement([], ldb.FLAG_MOD_DELETE, "schedule")
         try:
             samdb.modify(m)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e14:
+            (enum, estr) = e14.args
             raise KCCError("Could not modify nTDSConnection for (%s) - (%s)" %
                            (self.dnstr, estr))
 
@@ -1326,7 +1341,8 @@ class Partition(NamingContext):
             res = samdb.search(base=self.partstr, scope=ldb.SCOPE_BASE,
                                attrs=attrs)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e15:
+            (enum, estr) = e15.args
             raise KCCError("Unable to find partition for (%s) - (%s)" %
                            (self.partstr, estr))
         msg = res[0]
@@ -1466,7 +1482,8 @@ class Site(object):
                                attrs=attrs)
             self_res = samdb.search(base=self.site_dnstr, scope=ldb.SCOPE_BASE,
                                     attrs=['objectGUID'])
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e16:
+            (enum, estr) = e16.args
             raise KCCError("Unable to find site settings for (%s) - (%s)" %
                            (ssdn, estr))
 
@@ -1497,7 +1514,8 @@ class Site(object):
             res = samdb.search(self.site_dnstr,
                                scope=ldb.SCOPE_SUBTREE,
                                expression="(objectClass=nTDSDSA)")
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e17:
+            (enum, estr) = e17.args
             raise KCCError("Unable to find nTDSDSAs - (%s)" % estr)
 
         for msg in res:
@@ -1885,7 +1903,8 @@ class Transport(object):
             res = samdb.search(base=self.dnstr, scope=ldb.SCOPE_BASE,
                                attrs=attrs)
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e18:
+            (enum, estr) = e18.args
             raise KCCError("Unable to find Transport for (%s) - (%s)" %
                            (self.dnstr, estr))
 
@@ -2145,7 +2164,8 @@ class SiteLink(object):
             res = samdb.search(base=self.dnstr, scope=ldb.SCOPE_BASE,
                                attrs=attrs, controls=['extended_dn:0'])
 
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e19:
+            (enum, estr) = e19.args
             raise KCCError("Unable to find SiteLink for (%s) - (%s)" %
                            (self.dnstr, estr))
 

--- a/python/samba/kcc/ldif_import_export.py
+++ b/python/samba/kcc/ldif_import_export.py
@@ -109,7 +109,8 @@ def samdb_to_ldif_file(samdb, dburl, lp, creds, ldif_file):
         samdb = SamDB(url=dburl,
                       session_info=system_session(),
                       credentials=creds, lp=lp)
-    except ldb.LdbError, (enum, estr):
+    except ldb.LdbError as e:
+        (enum, estr) = e.args
         raise LdifError("Unable to open sam database (%s) : %s" %
                         (dburl, estr))
 
@@ -396,7 +397,8 @@ def samdb_to_ldif_file(samdb, dburl, lp, creds, ldif_file):
         # Write rootdse output
         write_search_result(samdb, f, res)
 
-    except ldb.LdbError, (enum, estr):
+    except ldb.LdbError as e1:
+        (enum, estr) = e1.args
         raise LdifError("Error processing (%s) : %s" % (sstr, estr))
 
     f.close()

--- a/python/samba/netcmd/domain.py
+++ b/python/samba/netcmd/domain.py
@@ -841,7 +841,8 @@ class cmd_domain_demote(Command):
 
                 try:
                     drsuapiBind.DsReplicaSync(drsuapi_handle, 1, req1)
-                except RuntimeError as (werr, string):
+                except RuntimeError as e1:
+                    (werr, string) = e1.args
                     if werr == werror.WERR_DS_DRA_NO_REPLICA:
                         pass
                     else:
@@ -981,7 +982,8 @@ class cmd_domain_demote(Command):
             req1.commit = 1
 
             drsuapiBind.DsRemoveDSServer(drsuapi_handle, 1, req1)
-        except RuntimeError as (werr, string):
+        except RuntimeError as e3:
+            (werr, string) = e3.args
             if not (dsa_options & DS_NTDSDSA_OPT_DISABLE_OUTBOUND_REPL) and not samdb.am_rodc():
                 self.errf.write(
                     "Error while demoting, re-enabling inbound replication\n")
@@ -1193,7 +1195,8 @@ class cmd_domain_level(Command):
                       ldb.FLAG_MOD_REPLACE, "nTMixedDomain")
                     try:
                         samdb.modify(m)
-                    except ldb.LdbError, (enum, emsg):
+                    except ldb.LdbError as e:
+                        (enum, emsg) = e.args
                         if enum != ldb.ERR_UNWILLING_TO_PERFORM:
                             raise
 
@@ -1213,7 +1216,8 @@ class cmd_domain_level(Command):
                           "msDS-Behavior-Version")
                 try:
                     samdb.modify(m)
-                except ldb.LdbError, (enum, emsg):
+                except ldb.LdbError as e2:
+                    (enum, emsg) = e2.args
                     if enum != ldb.ERR_UNWILLING_TO_PERFORM:
                         raise
 

--- a/python/samba/netcmd/drs.py
+++ b/python/samba/netcmd/drs.py
@@ -202,7 +202,8 @@ class cmd_drs_showrepl(Command):
                                                  scope=ldb.SCOPE_BASE,
                                                  attrs=["dnsHostName"])
                 d['dns name'] = c_server_res[0]["dnsHostName"][0]
-            except ldb.LdbError, (errno, _):
+            except ldb.LdbError as e:
+                (errno, _) = e.args
                 if errno == ldb.ERR_NO_SUCH_OBJECT:
                     d['is deleted'] = True
             except KeyError:

--- a/python/samba/netcmd/fsmo.py
+++ b/python/samba/netcmd/fsmo.py
@@ -40,7 +40,8 @@ def get_fsmo_roleowner(samdb, roledn, role):
     try:
         res = samdb.search(roledn,
                            scope=ldb.SCOPE_BASE, attrs=["fSMORoleOwner"])
-    except LdbError, (num, msg):
+    except LdbError as e7:
+        (num, msg) = e7.args
         if num == ldb.ERR_NO_SUCH_OBJECT:
             raise CommandError("The '%s' role is not present in this domain" % role)
         raise
@@ -74,7 +75,8 @@ def transfer_dns_role(outf, sambaopts, credopts, role, samdb):
                               res[0]['fSMORoleOwner'][0])
                               .get_extended_component('GUID')))
             master_owner = str(ldb.Dn(samdb, res[0]['fSMORoleOwner'][0]))
-        except LdbError, (num, msg):
+        except LdbError as e3:
+            (num, msg) = e3.args
             raise CommandError("No GUID found in naming master DN %s : %s \n" %
                                (res[0]['fSMORoleOwner'][0], msg))
     else:
@@ -109,7 +111,8 @@ def transfer_dns_role(outf, sambaopts, credopts, role, samdb):
 
         try:
             samdb.modify(m)
-        except LdbError, (num, msg):
+        except LdbError as e4:
+            (num, msg) = e4.args
             raise CommandError("Failed to delete role '%s': %s" %
                                (role, msg))
 
@@ -120,7 +123,8 @@ def transfer_dns_role(outf, sambaopts, credopts, role, samdb):
                                                "fSMORoleOwner")
         try:
             samdb.modify(m)
-        except LdbError, (num, msg):
+        except LdbError as e5:
+            (num, msg) = e5.args
             raise CommandError("Failed to add role '%s': %s" % (role, msg))
 
         try:
@@ -198,7 +202,8 @@ def transfer_role(outf, role, samdb):
     if master_owner != new_owner:
         try:
             samdb.modify(m)
-        except LdbError, (num, msg):
+        except LdbError as e6:
+            (num, msg) = e6.args
             raise CommandError("Transfer of '%s' role failed: %s" %
                                (role, msg))
 
@@ -303,7 +308,8 @@ You must provide an Admin user and password."""),
                     # We may need to allocate the initial RID Set
                     samdb.create_own_rid_set()
 
-            except LdbError, (num, msg):
+            except LdbError as e1:
+                (num, msg) = e1.args
                 if role == "rid" and num == ldb.ERR_ENTRY_ALREADY_EXISTS:
 
                     # Try again without the RID Set allocation
@@ -314,7 +320,8 @@ You must provide an Admin user and password."""),
                     samdb.transaction_start()
                     try:
                         samdb.modify(m)
-                    except LdbError, (num, msg):
+                    except LdbError as e:
+                        (num, msg) = e.args
                         samdb.transaction_cancel()
                         raise CommandError("Failed to seize '%s' role: %s" %
                                            (role, msg))
@@ -378,7 +385,8 @@ You must provide an Admin user and password."""),
                 "fSMORoleOwner")
             try:
                 samdb.modify(m)
-            except LdbError, (num, msg):
+            except LdbError as e2:
+                (num, msg) = e2.args
                 raise CommandError("Failed to seize '%s' role: %s" %
                                    (role, msg))
             self.outf.write("FSMO seize of '%s' role successful\n" % role)

--- a/python/samba/netcmd/ldapcmp.py
+++ b/python/samba/netcmd/ldapcmp.py
@@ -122,7 +122,8 @@ class LDAPBase(object):
         res = None
         try:
             res = self.ldb.search(base=object_dn, scope=SCOPE_BASE)
-        except LdbError, (enum, estr):
+        except LdbError as e2:
+            (enum, estr) = e2.args
             if enum == ERR_NO_SUCH_OBJECT:
                 return False
             raise
@@ -784,7 +785,8 @@ class LDAPBundel(object):
                                      summary=self.summary,
                                      filter_list=self.filter_list,
                                      outf=self.outf, errf=self.errf)
-            except LdbError, (enum, estr):
+            except LdbError as e:
+                (enum, estr) = e.args
                 if enum == ERR_NO_SUCH_OBJECT:
                     self.log( "\n!!! Object not found: %s" % self.dn_list[index] )
                     skip = True
@@ -795,7 +797,8 @@ class LDAPBundel(object):
                         summary=other.summary,
                         filter_list=self.filter_list,
                         outf=self.outf, errf=self.errf)
-            except LdbError, (enum, estr):
+            except LdbError as e1:
+                (enum, estr) = e1.args
                 if enum == ERR_NO_SUCH_OBJECT:
                     self.log( "\n!!! Object not found: %s" % other.dn_list[index] )
                     skip = True
@@ -851,7 +854,8 @@ class LDAPBundel(object):
             raise StandardError("Wrong 'scope' given. Choose from: SUB, ONE, BASE")
         try:
             res = self.con.ldb.search(base=self.search_base, scope=self.search_scope, attrs=["dn"])
-        except LdbError, (enum, estr):
+        except LdbError as e3:
+            (enum, estr) = e3.args
             self.outf.write("Failed search of base=%s\n" % self.search_base)
             raise
         for x in res:

--- a/python/samba/netcmd/user.py
+++ b/python/samba/netcmd/user.py
@@ -1037,7 +1037,8 @@ class GetPasswordCommand(Command):
                     nthash = tmp.get_nt_hash()
                     if nthash == unicodePwd:
                         calculated["Primary:CLEARTEXT"] = cv
-                except gpgme.GpgmeError as (major, minor, msg):
+                except gpgme.GpgmeError as e1:
+                    (major, minor, msg) = e1.args
                     if major == gpgme.ERR_BAD_SECKEY:
                         msg = "ERR_BAD_SECKEY: " + msg
                     else:
@@ -1970,7 +1971,8 @@ samba-tool user syncpasswords --terminate \\
 
             try:
                 self.lockfd = os.open(self.lockfile, flags, 0600)
-            except IOError as (err, msg):
+            except IOError as e4:
+                (err, msg) = e4.args
                 if err == errno.ENOENT:
                     if terminate:
                         return False
@@ -1982,7 +1984,8 @@ samba-tool user syncpasswords --terminate \\
             try:
                 fcntl.lockf(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 got_exclusive = True
-            except IOError as (err, msg):
+            except IOError as e5:
+                (err, msg) = e5.args
                 if err != errno.EACCES and err != errno.EAGAIN:
                     log_msg("check_current_pid_conflict: failed to get exclusive lock[%s] - %s (%d)" %
                             (self.lockfile, msg, err))
@@ -2001,7 +2004,8 @@ samba-tool user syncpasswords --terminate \\
             if got_exclusive and terminate:
                 try:
                     os.ftruncate(self.lockfd, 0)
-                except IOError as (err, msg):
+                except IOError as e2:
+                    (err, msg) = e2.args
                     log_msg("check_current_pid_conflict: failed to truncate [%s] - %s (%d)" %
                             (self.lockfile, msg, err))
                     raise
@@ -2011,7 +2015,8 @@ samba-tool user syncpasswords --terminate \\
 
             try:
                 fcntl.lockf(self.lockfd, fcntl.LOCK_SH)
-            except IOError as (err, msg):
+            except IOError as e6:
+                (err, msg) = e6.args
                 log_msg("check_current_pid_conflict: failed to get shared lock[%s] - %s (%d)" %
                         (self.lockfile, msg, err))
 
@@ -2026,7 +2031,8 @@ samba-tool user syncpasswords --terminate \\
                     try:
                         fcntl.lockf(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         got_exclusive = True
-                    except IOError as (err, msg):
+                    except IOError as e:
+                        (err, msg) = e.args
                         if err != errno.EACCES and err != errno.EAGAIN:
                             log_msg("update_pid(%r): failed to get exclusive lock[%s] - %s (%d)" %
                                     (pid, self.lockfile, msg, err))
@@ -2048,7 +2054,8 @@ samba-tool user syncpasswords --terminate \\
                     os.ftruncate(self.lockfd, 0)
                     if buf is not None:
                         os.write(self.lockfd, buf)
-                except IOError as (err, msg):
+                except IOError as e3:
+                    (err, msg) = e3.args
                     log_msg("check_current_pid_conflict: failed to write pid to [%s] - %s (%d)" %
                             (self.lockfile, msg, err))
                     raise
@@ -2279,7 +2286,8 @@ samba-tool user syncpasswords --terminate \\
 
             try:
                 sync_loop(wait)
-            except ldb.LdbError as (enum, estr):
+            except ldb.LdbError as e7:
+                (enum, estr) = e7.args
                 self.samdb = None
                 log_msg("ldb.LdbError(%d) => (%s)\n" % (enum, estr))
 

--- a/python/samba/provision/__init__.py
+++ b/python/samba/provision/__init__.py
@@ -428,7 +428,8 @@ def get_last_provision_usn(sam):
         entry = sam.search(expression="%s=*" % LAST_PROVISION_USN_ATTRIBUTE,
                        base="@PROVISION", scope=ldb.SCOPE_BASE,
                        attrs=[LAST_PROVISION_USN_ATTRIBUTE, "provisionnerID"])
-    except ldb.LdbError, (ecode, emsg):
+    except ldb.LdbError as e1:
+        (ecode, emsg) = e1.args
         if ecode == ldb.ERR_NO_SUCH_OBJECT:
             return None
         raise
@@ -1274,7 +1275,8 @@ def setup_samdb(path, session_info, provision_backend, lp, names,
     # DB
     try:
         samdb.connect(path)
-    except ldb.LdbError, (num, string_error):
+    except ldb.LdbError as e2:
+        (num, string_error) = e2.args
         if (num == ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS):
             raise ProvisioningError("Permission denied connecting to %s, are you running as root?" % path)
         else:
@@ -1902,7 +1904,8 @@ def provision_fill(samdb, secrets_ldb, logger, names, paths,
                 elements=kerberos_enctypes, flags=ldb.FLAG_MOD_REPLACE,
                 name="msDS-SupportedEncryptionTypes")
             samdb.modify(msg)
-        except ldb.LdbError, (enum, estr):
+        except ldb.LdbError as e:
+            (enum, estr) = e.args
             if enum != ldb.ERR_NO_SUCH_ATTRIBUTE:
                 # It might be that this attribute does not exist in this schema
                 raise

--- a/python/samba/remove_dc.py
+++ b/python/samba/remove_dc.py
@@ -54,7 +54,8 @@ def remove_sysvol_references(samdb, logger, dc_name):
         try:
             logger.info("Removing Sysvol reference: %s" % dn)
             samdb.delete(dn)
-        except ldb.LdbError as (enum, estr):
+        except ldb.LdbError as e:
+            (enum, estr) = e.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
             else:
@@ -77,7 +78,8 @@ def remove_sysvol_references(samdb, logger, dc_name):
         try:
             logger.info("Removing Sysvol reference: %s" % dn)
             samdb.delete(dn)
-        except ldb.LdbError as (enum, estr):
+        except ldb.LdbError as e1:
+            (enum, estr) = e1.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
             else:
@@ -98,7 +100,8 @@ def remove_dns_references(samdb, logger, dnsHostName, ignore_no_name=False):
 
     try:
         (dn, primary_recs) = samdb.dns_lookup(dnsHostName)
-    except RuntimeError as (enum, estr):
+    except RuntimeError as e4:
+        (enum, estr) = e4.args
         if enum == werror.WERR_DNS_ERROR_NAME_DOES_NOT_EXIST:
             if ignore_no_name:
                 remove_hanging_dns_references(samdb, logger,
@@ -145,7 +148,8 @@ def remove_dns_references(samdb, logger, dnsHostName, ignore_no_name=False):
         try:
             logger.debug("checking for DNS records to remove on %s" % a_name)
             (a_rec_dn, a_recs) = samdb.dns_lookup(a_name)
-        except RuntimeError as (enum, estr):
+        except RuntimeError as e2:
+            (enum, estr) = e2.args
             if enum == werror.WERR_DNS_ERROR_NAME_DOES_NOT_EXIST:
                 return
             raise DemoteException("lookup of %s failed: %s" % (a_name, estr))
@@ -300,7 +304,8 @@ def offline_remove_ntds_dc(samdb,
     try:
         msgs = samdb.search(base=ntds_dn, expression="objectClass=ntdsDSA",
                         attrs=["objectGUID"], scope=ldb.SCOPE_BASE)
-    except LdbError as (enum, estr):
+    except LdbError as e5:
+        (enum, estr) = e5.args
         if enum == ldb.ERR_NO_SUCH_OBJECT:
               raise DemoteException("Given DN %s doesn't exist" % ntds_dn)
         else:
@@ -349,7 +354,8 @@ def offline_remove_ntds_dc(samdb,
     try:
         logger.info("Removing nTDSDSA: %s (and any children)" % ntds_dn)
         samdb.delete(ntds_dn, ["tree_delete:0"])
-    except LdbError as (enum, estr):
+    except LdbError as e6:
+        (enum, estr) = e6.args
         raise DemoteException("Failed to remove the DCs NTDS DSA object: %s"
                               % estr)
 
@@ -381,7 +387,8 @@ def remove_dc(samdb, logger, dc_name):
                                        expression="(&(objectClass=server)"
                                        "(cn=%s))"
                                     % ldb.binary_encode(dc_name))
-        except LdbError as (enum, estr):
+        except LdbError as e3:
+            (enum, estr) = e3.args
             raise DemoteException("Failure checking if %s is an server "
                                   "object in %s: "
                                   % (dc_name, samdb.domain_dns_name()), estr)
@@ -399,7 +406,8 @@ def remove_dc(samdb, logger, dc_name):
     try:
         ntds_msgs = samdb.search(base=ntds_dn, attrs=[], scope=ldb.SCOPE_BASE,
                                  expression="(objectClass=ntdsdsa)")
-    except LdbError as (enum, estr):
+    except LdbError as e7:
+        (enum, estr) = e7.args
         if enum == ldb.ERR_NO_SUCH_OBJECT:
             ntds_msgs = []
             pass

--- a/python/samba/sites.py
+++ b/python/samba/sites.py
@@ -107,7 +107,8 @@ def delete_site(samdb, configDn, siteName):
                            expression="objectClass=site")
         if len(ret) != 1:
             raise SiteNotFoundException('Site %s does not exist' % siteName)
-    except LdbError as (enum, estr):
+    except LdbError as e:
+        (enum, estr) = e.args
         if enum == ldb.ERR_NO_SUCH_OBJECT:
             raise SiteNotFoundException('Site %s does not exist' % siteName)
 

--- a/python/samba/subnets.py
+++ b/python/samba/subnets.py
@@ -85,7 +85,8 @@ def create_subnet(samdb, configDn, subnet_name, site_name):
         m["siteObject"] = ldb.MessageElement(str(dn_site), FLAG_MOD_ADD,
                                              "siteObject")
         samdb.add(m)
-    except ldb.LdbError as (enum, estr):
+    except ldb.LdbError as e:
+        (enum, estr) = e.args
         if enum == ldb.ERR_INVALID_DN_SYNTAX:
             raise SubnetInvalid("%s is not a valid subnet: %s" % (subnet_name, estr))
         elif enum == ldb.ERR_ENTRY_ALREADY_EXISTS:
@@ -121,7 +122,8 @@ def delete_subnet(samdb, configDn, subnet_name):
                            expression="objectClass=subnet")
         if len(ret) != 1:
             raise SubnetNotFound('Subnet %s does not exist' % subnet_name)
-    except LdbError as (enum, estr):
+    except LdbError as e1:
+        (enum, estr) = e1.args
         if enum == ldb.ERR_NO_SUCH_OBJECT:
             raise SubnetNotFound('Subnet %s does not exist' % subnet_name)
 
@@ -149,7 +151,8 @@ def rename_subnet(samdb, configDn, subnet_name, new_name):
     newdnsubnet.set_component(0, "CN", new_name)
     try:
         samdb.rename(dnsubnet, newdnsubnet)
-    except LdbError as (enum, estr):
+    except LdbError as e2:
+        (enum, estr) = e2.args
         if enum == ldb.ERR_NO_SUCH_OBJECT:
             raise SubnetNotFound('Subnet %s does not exist' % subnet)
         elif enum == ldb.ERR_ENTRY_ALREADY_EXISTS:
@@ -187,7 +190,8 @@ def set_subnet_site(samdb, configDn, subnet_name, site_name):
                            expression="objectClass=subnet")
         if len(ret) != 1:
             raise SubnetNotFound('Subnet %s does not exist' % subnet_name)
-    except LdbError as (enum, estr):
+    except LdbError as e3:
+        (enum, estr) = e3.args
         if enum == ldb.ERR_NO_SUCH_OBJECT:
             raise SubnetNotFound('Subnet %s does not exist' % subnet_name)
 
@@ -206,7 +210,8 @@ def set_subnet_site(samdb, configDn, subnet_name, site_name):
                            expression="objectClass=site")
         if len(ret) != 1:
             raise SiteNotFoundException('Site %s does not exist' % site_name)
-    except LdbError as (enum, estr):
+    except LdbError as e4:
+        (enum, estr) = e4.args
         if enum == ldb.ERR_NO_SUCH_OBJECT:
             raise SiteNotFoundException('Site %s does not exist' % site_name)
 

--- a/python/samba/tests/auth_log_pass_change.py
+++ b/python/samba/tests/auth_log_pass_change.py
@@ -290,7 +290,8 @@ class AuthLogPassChangeTests(samba.tests.auth_log_base.AuthLogTestBase):
                 "userPassword: " + new_password + "\n"
             )
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e:
+            (num, msg) = e.args
             pass
 
         messages = self.waitForMessages(isLastExpectedMessage)
@@ -320,7 +321,8 @@ class AuthLogPassChangeTests(samba.tests.auth_log_base.AuthLogTestBase):
                 "userPassword: " + new_password + "\n"
             )
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e1:
+            (num, msg) = e1.args
             pass
 
         messages = self.waitForMessages(isLastExpectedMessage)

--- a/python/samba/tests/dns.py
+++ b/python/samba/tests/dns.py
@@ -890,7 +890,8 @@ class TestZones(DNSTest):
         super(TestZones, self).tearDown()
         try:
             self.delete_zone(self.zone)
-        except RuntimeError, (num, string):
+        except RuntimeError as e:
+            (num, string) = e.args
             if num != werror.WERR_DNS_ERROR_ZONE_DOES_NOT_EXIST:
                 raise
 

--- a/python/samba/tests/samba_tool/fsmo.py
+++ b/python/samba/tests/samba_tool/fsmo.py
@@ -37,7 +37,8 @@ class FsmoCmdTestCase(SambaToolCmdTest):
                        scope=ldb.SCOPE_BASE, attrs=["fsmoRoleOwner"])
 
             self.assertTrue("DomainDnsZonesMasterRole owner: " + res[0]["fsmoRoleOwner"][0] in out)
-        except ldb.LdbError, (enum, string):
+        except ldb.LdbError as e:
+            (enum, string) = e.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 self.assertTrue("The 'domaindns' role is not present in this domain" in out)
             else:

--- a/python/samba/tests/samdb_api.py
+++ b/python/samba/tests/samdb_api.py
@@ -56,7 +56,8 @@ class SamDBApiTestCase(TestCaseInTempDir):
         try:
             SamDB(url="tdb://" + existing_name)
             self.fail("Exception not thrown ")
-        except LdbError as (err, _):
+        except LdbError as e:
+            (err, _) = e.args
             self.assertEquals(err, ERR_OPERATIONS_ERROR)
 
         existing = open(existing_name, "r")
@@ -136,7 +137,8 @@ class SamDBApiTestCase(TestCaseInTempDir):
         try:
             SamDB(url="tdb://" + self.tempdir + "/test.db")
             self.fail("Exception not thrown ")
-        except LdbError as (err, _):
+        except LdbError as e1:
+            (err, _) = e1.args
             self.assertEquals(err, ERR_OPERATIONS_ERROR)
 
         try:

--- a/python/samba/upgrade.py
+++ b/python/samba/upgrade.py
@@ -255,7 +255,8 @@ def add_group_from_mapping_entry(samdb, groupmap, logger):
         msg = samdb.search(
             base='<SID=%s>' % str(groupmap.sid), scope=ldb.SCOPE_BASE)
         found = True
-    except ldb.LdbError, (ecode, emsg):
+    except ldb.LdbError as e1:
+        (ecode, emsg) = e1.args
         if ecode == ldb.ERR_NO_SUCH_OBJECT:
             found = False
         else:
@@ -312,7 +313,8 @@ def add_users_to_group(samdb, group, members, logger):
 
         try:
             samdb.modify(m)
-        except ldb.LdbError, (ecode, emsg):
+        except ldb.LdbError as e:
+            (ecode, emsg) = e.args
             if ecode == ldb.ERR_ENTRY_ALREADY_EXISTS:
                 logger.debug("skipped re-adding member '%s' to group '%s': %s", member_sid, group.sid, emsg)
             elif ecode == ldb.ERR_NO_SUCH_OBJECT:

--- a/source4/dsdb/tests/python/acl.py
+++ b/source4/dsdb/tests/python/acl.py
@@ -199,7 +199,8 @@ class AclAddTests(AclTests):
             self.ldb_user.newuser(self.test_user1, self.user_pass, userou=self.ou2)
             self.ldb_user.newgroup("test_add_group1", groupou="OU=test_add_ou2,OU=test_add_ou1",
                                    grouptype=samba.dsdb.GTYPE_DISTRIBUTION_DOMAIN_LOCAL_GROUP)
-        except LdbError, (num, _):
+        except LdbError as e:
+            (num, _) = e.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -223,7 +224,8 @@ class AclAddTests(AclTests):
         try:
             self.ldb_user.newgroup("test_add_group1", groupou="OU=test_add_ou2,OU=test_add_ou1",
                                    grouptype=samba.dsdb.GTYPE_DISTRIBUTION_DOMAIN_LOCAL_GROUP)
-        except LdbError, (num, _):
+        except LdbError as e1:
+            (num, _) = e1.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -259,7 +261,8 @@ class AclAddTests(AclTests):
         anonymous = SamDB(url=ldaphost, credentials=self.creds_tmp, lp=lp)
         try:
             anonymous.newuser("test_add_anonymous", self.user_pass)
-        except LdbError, (num, _):
+        except LdbError as e2:
+            (num, _) = e2.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         else:
             self.fail()
@@ -370,7 +373,8 @@ replace: url
 url: www.samba.org"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e3:
+            (num, _) = e3.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -398,7 +402,8 @@ replace: url
 url: www.samba.org"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e4:
+            (num, _) = e4.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -413,7 +418,8 @@ replace: displayName
 displayName: test_changed"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e5:
+            (num, _) = e5.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -440,7 +446,8 @@ replace: url
 url: www.samba.org"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e6:
+            (num, _) = e6.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -459,7 +466,8 @@ replace: url
 url: www.samba.org"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e7:
+            (num, _) = e7.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -477,7 +485,8 @@ replace: url
 url: www.samba.org"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e8:
+            (num, _) = e8.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -495,7 +504,8 @@ replace: url
 url: www.samba.org"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e9:
+            (num, _) = e9.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -511,7 +521,8 @@ add: adminDescription
 adminDescription: blah blah blah"""
         try:
             self.ldb_user.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e10:
+            (num, _) = e10.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -535,7 +546,8 @@ Member: """ +  self.get_user_dn(self.user_with_sm)
 #the user has no rights granted, this should fail
         try:
             self.ldb_user2.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e11:
+            (num, _) = e11.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This 'modify' operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -557,7 +569,8 @@ add: Member
 Member: CN=test_modify_user2,CN=Users,""" + self.base_dn
         try:
             self.ldb_user2.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e12:
+            (num, _) = e12.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -577,7 +590,8 @@ Member: CN=test_modify_user2,CN=Users,""" + self.base_dn
         self.sd_utils.dacl_add_ace("CN=test_modify_group2,CN=Users," + self.base_dn, mod)
         try:
             self.ldb_user2.modify_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e13:
+            (num, _) = e13.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -624,7 +638,8 @@ Member: CN=test_modify_user2,CN=Users,""" + self.base_dn
                                           "description")
         try:
             anonymous.modify(m)
-        except LdbError, (num, _):
+        except LdbError as e14:
+            (num, _) = e14.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         else:
             self.fail()
@@ -734,20 +749,23 @@ class AclSearchTests(AclTests):
         anonymous = SamDB(url=ldaphost, credentials=self.creds_tmp, lp=lp)
         try:
             res = anonymous.search("", expression="(objectClass=*)", scope=SCOPE_SUBTREE)
-        except LdbError, (num, _):
+        except LdbError as e15:
+            (num, _) = e15.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         else:
             self.fail()
         try:
             res = anonymous.search(self.base_dn, expression="(objectClass=*)", scope=SCOPE_SUBTREE)
-        except LdbError, (num, _):
+        except LdbError as e16:
+            (num, _) = e16.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         else:
             self.fail()
         try:
             res = anonymous.search(anonymous.get_config_basedn(), expression="(objectClass=*)",
                                         scope=SCOPE_SUBTREE)
-        except LdbError, (num, _):
+        except LdbError as e17:
+            (num, _) = e17.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         else:
             self.fail()
@@ -857,7 +875,8 @@ class AclSearchTests(AclTests):
         try:
              self.ldb_user3.search("OU=ou3,OU=ou2,OU=ou1," + self.base_dn, expression="(objectClass=*)",
                                    scope=SCOPE_BASE)
-        except LdbError, (num, _):
+        except LdbError as e18:
+            (num, _) = e18.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
         else:
             self.fail()
@@ -1023,7 +1042,8 @@ class AclDeleteTests(AclTests):
         # Here delete User object should ALWAYS through exception
         try:
             self.ldb_user.delete(self.get_user_dn("test_delete_user1"))
-        except LdbError, (num, _):
+        except LdbError as e19:
+            (num, _) = e19.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1061,7 +1081,8 @@ class AclDeleteTests(AclTests):
 
         try:
             anonymous.delete(self.get_user_dn("test_anonymous"))
-        except LdbError, (num, _):
+        except LdbError as e20:
+            (num, _) = e20.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         else:
             self.fail()
@@ -1114,7 +1135,8 @@ class AclRenameTests(AclTests):
         try:
             self.ldb_user.rename("CN=%s,%s,%s" % (self.testuser1, self.ou1, self.base_dn), \
                                      "CN=%s,%s,%s" % (self.testuser5, self.ou1, self.base_dn))
-        except LdbError, (num, _):
+        except LdbError as e21:
+            (num, _) = e21.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1271,7 +1293,8 @@ class AclRenameTests(AclTests):
         self.sd_utils.dacl_add_ace(ou2_dn, mod)
         try:
             self.ldb_user.rename(ou2_dn, ou3_dn)
-        except LdbError, (num, _):
+        except LdbError as e22:
+            (num, _) = e22.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             # This rename operation should always throw ERR_INSUFFICIENT_ACCESS_RIGHTS
@@ -1302,7 +1325,8 @@ class AclRenameTests(AclTests):
         # Rename 'User object' having SD and CC to AU
         try:
             self.ldb_admin.rename(user_dn, rename_user_dn)
-        except LdbError, (num, _):
+        except LdbError as e23:
+            (num, _) = e23.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1362,7 +1386,8 @@ unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')) + """
 add: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
 """)
-        except LdbError, (num, _):
+        except LdbError as e24:
+            (num, _) = e24.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         else:
             # for some reason we get constraint violation instead of insufficient access error
@@ -1388,7 +1413,8 @@ unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')) + """
 add: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
 """)
-        except LdbError, (num, _):
+        except LdbError as e25:
+            (num, _) = e25.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         else:
             # for some reason we get constraint violation instead of insufficient access error
@@ -1427,7 +1453,8 @@ dBCSPwd: XXXXXXXXXXXXXXXX
 add: dBCSPwd
 dBCSPwd: YYYYYYYYYYYYYYYY
 """)
-        except LdbError, (num, _):
+        except LdbError as e26:
+            (num, _) = e26.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         else:
             self.fail()
@@ -1445,7 +1472,8 @@ userPassword: thatsAcomplPASS1
 add: userPassword
 userPassword: thatsAcomplPASS2
 """)
-        except LdbError, (num, _):
+        except LdbError as e27:
+            (num, _) = e27.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1463,7 +1491,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             # This fails on Windows 2000 domain level with constraint violation
-        except LdbError, (num, _):
+        except LdbError as e28:
+            (num, _) = e28.args
             self.assertTrue(num == ERR_CONSTRAINT_VIOLATION or
                             num == ERR_UNWILLING_TO_PERFORM)
         else:
@@ -1504,7 +1533,8 @@ changetype: modify
 replace: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
 """)
-        except LdbError, (num, _):
+        except LdbError as e29:
+            (num, _) = e29.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1526,7 +1556,8 @@ changetype: modify
 replace: userPassword
 userPassword: thatsAcomplPASS1
 """)
-        except LdbError, (num, _):
+        except LdbError as e30:
+            (num, _) = e30.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1540,7 +1571,8 @@ replace: userPassword
 userPassword: thatsAcomplPASS1
 """)
             # This fails on Windows 2000 domain level with constraint violation
-        except LdbError, (num, _):
+        except LdbError as e31:
+            (num, _) = e31.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
     def test_reset_password3(self):
@@ -1554,7 +1586,8 @@ changetype: modify
 replace: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
 """)
-        except LdbError, (num, _):
+        except LdbError as e32:
+            (num, _) = e32.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1570,7 +1603,8 @@ changetype: modify
 replace: userPassword
 userPassword: thatsAcomplPASS1
 """)
-        except LdbError, (num, _):
+        except LdbError as e33:
+            (num, _) = e33.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         else:
             self.fail()
@@ -1598,7 +1632,8 @@ replace: userPassword
 userPassword: thatsAcomplPASS1
 """)
             # This fails on Windows 2000 domain level with constraint violation
-        except LdbError, (num, _):
+        except LdbError as e34:
+            (num, _) = e34.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
 class AclExtendedTests(AclTests):
@@ -1756,7 +1791,8 @@ class AclUndeleteTests(AclTests):
         try:
             self.undelete_deleted(self.deleted_dn1, self.testuser1_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e35:
+            (num, _) = e35.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         # seems that permissions on isDeleted and distinguishedName are irrelevant
@@ -1772,7 +1808,8 @@ class AclUndeleteTests(AclTests):
         try:
             self.undelete_deleted_with_mod(self.deleted_dn3, self.testuser3_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e36:
+            (num, _) = e36.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         # undelete in an ou, in which we have no right to create children
@@ -1781,7 +1818,8 @@ class AclUndeleteTests(AclTests):
         try:
             self.undelete_deleted(self.deleted_dn4, self.new_dn_ou)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e37:
+            (num, _) = e37.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         # delete is not required
@@ -1795,7 +1833,8 @@ class AclUndeleteTests(AclTests):
         try:
             self.undelete_deleted(self.deleted_dn4, self.testuser4_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e38:
+            (num, _) = e38.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
 class AclSPNTests(AclTests):
@@ -1905,7 +1944,8 @@ class AclSPNTests(AclTests):
         netbiosdomain = self.dcctx.get_domain_name()
         try:
             self.replace_spn(self.ldb_user1, ctx.acct_dn, "HOST/%s/%s" % (ctx.myname, netbiosdomain))
-        except LdbError, (num, _):
+        except LdbError as e39:
+            (num, _) = e39.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         mod = "(OA;;SW;f3a64788-5306-11d1-a9c5-0000f80367c1;;%s)" % str(self.user_sid1)
@@ -1942,26 +1982,31 @@ class AclSPNTests(AclTests):
         try:
             self.replace_spn(self.ldb_user1, ctx.acct_dn, "ldap/%s.%s/ForestDnsZones.%s" %
                              (ctx.myname, ctx.dnsdomain, ctx.dnsdomain))
-        except LdbError, (num, _):
+        except LdbError as e40:
+            (num, _) = e40.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, ctx.acct_dn, "ldap/%s.%s/DomainDnsZones.%s" %
                              (ctx.myname, ctx.dnsdomain, ctx.dnsdomain))
-        except LdbError, (num, _):
+        except LdbError as e41:
+            (num, _) = e41.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, ctx.acct_dn, "nosuchservice/%s/%s" % ("abcd", "abcd"))
-        except LdbError, (num, _):
+        except LdbError as e42:
+            (num, _) = e42.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, ctx.acct_dn, "GC/%s.%s/%s" %
                              (ctx.myname, ctx.dnsdomain, netbiosdomain))
-        except LdbError, (num, _):
+        except LdbError as e43:
+            (num, _) = e43.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, ctx.acct_dn, "E3514235-4B06-11D1-AB04-00C04FC2DCD2/%s/%s" %
                              (ctx.ntds_guid, ctx.dnsdomain))
-        except LdbError, (num, _):
+        except LdbError as e44:
+            (num, _) = e44.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
     def test_computer_spn(self):
@@ -2005,7 +2050,8 @@ class AclSPNTests(AclTests):
         #user has neither WP nor Validated-SPN, access denied expected
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "HOST/%s/%s" % (self.computername, netbiosdomain))
-        except LdbError, (num, _):
+        except LdbError as e45:
+            (num, _) = e45.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         mod = "(OA;;SW;f3a64788-5306-11d1-a9c5-0000f80367c1;;%s)" % str(self.user_sid1)
@@ -2022,36 +2068,43 @@ class AclSPNTests(AclTests):
 
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "HOST/%s/%s" % (self.computername, netbiosdomain))
-        except LdbError, (num, _):
+        except LdbError as e46:
+            (num, _) = e46.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "HOST/%s.%s/%s" %
                              (self.computername, self.dcctx.dnsdomain, netbiosdomain))
-        except LdbError, (num, _):
+        except LdbError as e47:
+            (num, _) = e47.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "HOST/%s/%s" %
                              (self.computername, self.dcctx.dnsdomain))
-        except LdbError, (num, _):
+        except LdbError as e48:
+            (num, _) = e48.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "HOST/%s.%s/%s" %
                              (self.computername, self.dcctx.dnsdomain, self.dcctx.dnsdomain))
-        except LdbError, (num, _):
+        except LdbError as e49:
+            (num, _) = e49.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "GC/%s.%s/%s" %
                              (self.computername, self.dcctx.dnsdomain, self.dcctx.dnsforest))
-        except LdbError, (num, _):
+        except LdbError as e50:
+            (num, _) = e50.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "ldap/%s/%s" % (self.computername, netbiosdomain))
-        except LdbError, (num, _):
+        except LdbError as e51:
+            (num, _) = e51.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         try:
             self.replace_spn(self.ldb_user1, self.computerdn, "ldap/%s.%s/ForestDnsZones.%s" %
                              (self.computername, self.dcctx.dnsdomain, self.dcctx.dnsdomain))
-        except LdbError, (num, _):
+        except LdbError as e52:
+            (num, _) = e52.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
     def test_spn_rwdc(self):

--- a/source4/dsdb/tests/python/ad_dc_medley_performance.py
+++ b/source4/dsdb/tests/python/ad_dc_medley_performance.py
@@ -216,7 +216,8 @@ class UserTests(samba.tests.TestCase):
                     self.ldb.search(dn,
                                     scope=SCOPE_BASE,
                                     attrs=['cn'])
-                except LdbError as (num, msg):
+                except LdbError as e:
+                    (num, msg) = e.args
                     if num != 32:
                         raise
 

--- a/source4/dsdb/tests/python/deletetest.py
+++ b/source4/dsdb/tests/python/deletetest.py
@@ -114,7 +114,8 @@ class BasicDeleteTests(BaseDeleteTests):
         try:
             ldb.delete(dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e:
+            (num, _) = e.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
     def test_delete_protection(self):
@@ -139,7 +140,8 @@ class BasicDeleteTests(BaseDeleteTests):
         try:
             self.ldb.delete("cn=ldaptestcontainer," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e1:
+            (num, _) = e1.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_NON_LEAF)
 
         self.ldb.delete("cn=ldaptestcontainer," + self.base_dn, ["tree_delete:1"])
@@ -148,19 +150,22 @@ class BasicDeleteTests(BaseDeleteTests):
             res = self.ldb.search("cn=ldaptestcontainer," + self.base_dn,
                              scope=SCOPE_BASE, attrs=[])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e2:
+            (num, _) = e2.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
         try:
             res = self.ldb.search("cn=entry1,cn=ldaptestcontainer," + self.base_dn,
                              scope=SCOPE_BASE, attrs=[])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e3:
+            (num, _) = e3.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
         try:
             res = self.ldb.search("cn=entry2,cn=ldaptestcontainer," + self.base_dn,
                              scope=SCOPE_BASE, attrs=[])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e4:
+            (num, _) = e4.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         delete_force(self.ldb, "cn=entry1,cn=ldaptestcontainer," + self.base_dn)
@@ -177,7 +182,8 @@ class BasicDeleteTests(BaseDeleteTests):
         try:
             self.ldb.delete(res[0]["dsServiceName"][0])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e5:
+            (num, _) = e5.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         res = self.ldb.search(self.base_dn, attrs=["rIDSetReferences"],
@@ -188,12 +194,14 @@ class BasicDeleteTests(BaseDeleteTests):
         try:
             self.ldb.delete(res[0]["rIDSetReferences"][0])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e6:
+            (num, _) = e6.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         try:
             self.ldb.delete(res[0]["rIDSetReferences"][0], ["tree_delete:1"])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e7:
+            (num, _) = e7.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Deletes failing since three main crossRef objects are protected
@@ -201,23 +209,27 @@ class BasicDeleteTests(BaseDeleteTests):
         try:
             self.ldb.delete("cn=Enterprise Schema,cn=Partitions," + self.configuration_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e8:
+            (num, _) = e8.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         try:
             self.ldb.delete("cn=Enterprise Schema,cn=Partitions," + self.configuration_dn, ["tree_delete:1"])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e9:
+            (num, _) = e9.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
             self.ldb.delete("cn=Enterprise Configuration,cn=Partitions," + self.configuration_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e10:
+            (num, _) = e10.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_NON_LEAF)
         try:
             self.ldb.delete("cn=Enterprise Configuration,cn=Partitions," + self.configuration_dn, ["tree_delete:1"])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e11:
+            (num, _) = e11.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_NON_LEAF)
 
         res = self.ldb.search("cn=Partitions," + self.configuration_dn, attrs=[],
@@ -227,26 +239,30 @@ class BasicDeleteTests(BaseDeleteTests):
         try:
             self.ldb.delete(res[0].dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e12:
+            (num, _) = e12.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_NON_LEAF)
         try:
             self.ldb.delete(res[0].dn, ["tree_delete:1"])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e13:
+            (num, _) = e13.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_NON_LEAF)
 
         # Delete failing since "SYSTEM_FLAG_DISALLOW_DELETE"
         try:
             self.ldb.delete("CN=Users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e14:
+            (num, _) = e14.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Tree-delete failing since "isCriticalSystemObject"
         try:
             self.ldb.delete("CN=Computers," + self.base_dn, ["tree_delete:1"])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e15:
+            (num, _) = e15.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
     def test_all(self):

--- a/source4/dsdb/tests/python/dsdb_schema_info.py
+++ b/source4/dsdb/tests/python/dsdb_schema_info.py
@@ -140,7 +140,8 @@ systemOnly: FALSE
         attr_dn_new = attr_dn.replace(attr_name, attr_name + "-NEW")
         try:
             self.sam_db.rename(attr_dn, attr_dn_new)
-        except LdbError, (num, _):
+        except LdbError as e:
+            (num, _) = e.args
             self.fail("failed to change CN for %s: %s" % (attr_name, _))
 
         # compare resulting schemaInfo
@@ -186,7 +187,8 @@ systemOnly: FALSE
         class_dn_new = class_dn.replace(class_name, class_name + "-NEW")
         try:
             self.sam_db.rename(class_dn, class_dn_new)
-        except LdbError, (num, _):
+        except LdbError as e1:
+            (num, _) = e1.args
             self.fail("failed to change CN for %s: %s" % (class_name, _))
 
         # compare resulting schemaInfo

--- a/source4/dsdb/tests/python/ldap.py
+++ b/source4/dsdb/tests/python/ldap.py
@@ -116,7 +116,8 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectClass": [] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e1:
+            (num, _) = e1.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # Invalid objectclass specified
@@ -125,7 +126,8 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectClass": "X" })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e2:
+            (num, _) = e2.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         # Invalid objectCategory specified
@@ -135,7 +137,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectClass": "person",
                 "objectCategory": self.base_dn })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e3:
+            (num, _) = e3.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Multi-valued "systemFlags"
@@ -145,7 +148,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectClass": "person",
                 "systemFlags": ["0", str(SYSTEM_FLAG_DOMAIN_DISALLOW_MOVE)] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e4:
+            (num, _) = e4.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # We cannot instanciate from an abstract object class ("connectionPoint"
@@ -159,14 +163,16 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectClass": "connectionPoint" })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e5:
+            (num, _) = e5.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         try:
             self.ldb.add({
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectClass": ["person", "leaf"] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e6:
+            (num, _) = e6.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Objects instanciated using "satisfied" abstract classes (concrete
@@ -183,7 +189,8 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectClass": ["person", "container"] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e7:
+            (num, _) = e7.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Test allowed system flags
@@ -225,7 +232,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e8:
+            (num, _) = e8.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # We cannot delete classes which weren't specified
@@ -236,7 +244,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e9:
+            (num, _) = e9.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         # An invalid class cannot be added
@@ -247,7 +256,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e10:
+            (num, _) = e10.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         # We cannot add a the new top-most structural class "user" here since
@@ -260,7 +270,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e11:
+            (num, _) = e11.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # An already specified objectclass cannot be added another time
@@ -271,7 +282,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e12:
+            (num, _) = e12.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         # Auxiliary classes can always be added
@@ -290,7 +302,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e13:
+            (num, _) = e13.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Objectclass replace operations can be performed as well
@@ -315,7 +328,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e14:
+            (num, _) = e14.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # More than one change operation is allowed
@@ -332,7 +346,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e15:
+            (num, _) = e15.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         m = Message()
@@ -342,7 +357,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e16:
+            (num, _) = e16.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Classes can be removed unless attributes of them are used.
@@ -379,7 +395,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e17:
+            (num, _) = e17.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Remove the previously specified attribute
@@ -411,7 +428,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e18:
+            (num, _) = e18.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Add a new top-most structural class "inetOrgPerson" and remove it
@@ -466,7 +484,8 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestobject," + self.base_dn,
                 "objectclass": "configuration"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e19:
+            (num, _) = e19.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -474,7 +493,8 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "cn=Test Secret,cn=system," + self.base_dn,
                 "objectclass": "secret"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e20:
+            (num, _) = e20.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "cn=ldaptestobject," + self.base_dn)
@@ -500,7 +520,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e21:
+            (num, _) = e21.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "cn=Test Secret,cn=system," + self.base_dn)
@@ -511,7 +532,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectclass": "container",
                 "isCriticalSystemObject": "TRUE"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e22:
+            (num, _) = e22.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         self.ldb.add({
@@ -525,7 +547,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e23:
+            (num, _) = e23.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "cn=ldaptestcontainer," + self.base_dn)
@@ -552,7 +575,8 @@ class BasicTests(samba.tests.TestCase):
                    + self.base_dn,
                 "objectclass": "group"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e24:
+            (num, _) = e24.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=thisdoesnotexist123,"
@@ -563,7 +587,8 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "ou=testou,cn=users," + self.base_dn,
                 "objectclass": "organizationalUnit"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e25:
+            (num, _) = e25.args
             self.assertEquals(num, ERR_NAMING_VIOLATION)
 
         delete_force(self.ldb, "ou=testou,cn=users," + self.base_dn)
@@ -580,7 +605,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "thisdoesnotexist": "x"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e26:
+            (num, _) = e26.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         self.ldb.add({
@@ -596,7 +622,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e27:
+            (num, _) = e27.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
@@ -613,7 +640,8 @@ class BasicTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestobject," + self.base_dn,
                 "objectclass": "ipProtocol"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e28:
+            (num, _) = e28.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # inadequate but schema-valid attribute specified
@@ -624,7 +652,8 @@ class BasicTests(samba.tests.TestCase):
                 "ipProtocolNumber": "1",
                 "uid" : "0"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e29:
+            (num, _) = e29.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         self.ldb.add({
@@ -641,7 +670,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e30:
+            (num, _) = e30.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # mandatory attribute delete trial
@@ -652,7 +682,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e31:
+            (num, _) = e31.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # mandatory attribute delete trial
@@ -663,7 +694,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e32:
+            (num, _) = e32.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         delete_force(self.ldb, "cn=ldaptestobject," + self.base_dn)
@@ -676,7 +708,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "sAMAccountName": ["nam1", "nam2"]})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e33:
+            (num, _) = e33.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         self.ldb.add({
@@ -690,7 +723,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e34:
+            (num, _) = e34.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -706,7 +740,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e35:
+            (num, _) = e35.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
@@ -740,7 +775,8 @@ class BasicTests(samba.tests.TestCase):
                 "managedBy": managers
             })
             self.fail("failed to fail to add multiple managedBy attributes")
-        except LdbError as (num, _):
+        except LdbError as e36:
+            (num, _) = e36.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         managee = "cn=group2," + ou
@@ -756,7 +792,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e37:
+            (num, _) = e37.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -772,7 +809,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e38:
+            (num, _) = e38.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         self.ldb.delete(ou, ['tree_delete:1'])
@@ -859,7 +897,8 @@ class BasicTests(samba.tests.TestCase):
                "objectClass": "person",
                "sn": "" })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e39:
+            (num, _) = e39.args
             self.assertEquals(num, ERR_INVALID_ATTRIBUTE_SYNTAX)
 
         # Too long (max. 64)
@@ -883,7 +922,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e40:
+            (num, _) = e40.args
             self.assertEquals(num, ERR_INVALID_ATTRIBUTE_SYNTAX)
 
         # Too long (max. 64)
@@ -911,13 +951,15 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.add(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e41:
+            (num, _) = e41.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e42:
+            (num, _) = e42.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
@@ -932,7 +974,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.add(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e43:
+            (num, _) = e43.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         self.ldb.add({
@@ -946,7 +989,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e44:
+            (num, _) = e44.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -960,7 +1004,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e45:
+            (num, _) = e45.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
@@ -974,7 +1019,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "instanceType": ["0", "1"]})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e46:
+            (num, _) = e46.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # The head NC flag cannot be set without the write flag
@@ -984,7 +1030,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "instanceType": "1" })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e47:
+            (num, _) = e47.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # We cannot manipulate NCs without the head NC flag
@@ -994,7 +1041,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "instanceType": "32" })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e48:
+            (num, _) = e48.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         self.ldb.add({
@@ -1008,7 +1056,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e49:
+            (num, _) = e49.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -1018,7 +1067,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e50:
+            (num, _) = e50.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -1027,7 +1077,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e51:
+            (num, _) = e51.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
@@ -1039,7 +1090,8 @@ class BasicTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "instanceType": "3" })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e52:
+            (num, _) = e52.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         delete_force(self.ldb, "cn=ldaptestuser2,cn=users," + self.base_dn)
 
@@ -1054,7 +1106,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.add(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e53:
+            (num, _) = e53.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         # a wrong "distinguishedName" attribute is obviously tolerated
@@ -1080,7 +1133,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e54:
+            (num, _) = e54.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         m = Message()
@@ -1092,7 +1146,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e55:
+            (num, _) = e55.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -1104,7 +1159,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e56:
+            (num, _) = e56.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -1116,7 +1172,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e57:
+            (num, _) = e57.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
@@ -1129,20 +1186,23 @@ class BasicTests(samba.tests.TestCase):
         try:
             self.ldb.search("=,cn=users," + self.base_dn, scope=SCOPE_BASE)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e58:
+            (num, _) = e58.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # empty RDN name
         try:
             self.ldb.search("cn=,cn=users," + self.base_dn, scope=SCOPE_BASE)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e59:
+            (num, _) = e59.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         try:
             self.ldb.search("=ldaptestgroup,cn=users," + self.base_dn, scope=SCOPE_BASE)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e60:
+            (num, _) = e60.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # Add
@@ -1153,7 +1213,8 @@ class BasicTests(samba.tests.TestCase):
                  "dn": "=,cn=users," + self.base_dn,
                  "objectclass": "group"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e61:
+            (num, _) = e61.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # empty RDN name
@@ -1162,7 +1223,8 @@ class BasicTests(samba.tests.TestCase):
                  "dn": "=ldaptestgroup,cn=users," + self.base_dn,
                  "objectclass": "group"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e62:
+            (num, _) = e62.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # empty RDN value
@@ -1171,7 +1233,8 @@ class BasicTests(samba.tests.TestCase):
                  "dn": "cn=,cn=users," + self.base_dn,
                  "objectclass": "group"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e63:
+            (num, _) = e63.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # a wrong RDN candidate
@@ -1180,7 +1243,8 @@ class BasicTests(samba.tests.TestCase):
                  "dn": "description=xyz,cn=users," + self.base_dn,
                  "objectclass": "group"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e64:
+            (num, _) = e64.args
             self.assertEquals(num, ERR_NAMING_VIOLATION)
 
         delete_force(self.ldb, "description=xyz,cn=users," + self.base_dn)
@@ -1207,7 +1271,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e65:
+            (num, _) = e65.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # Delete
@@ -1216,7 +1281,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             self.ldb.delete("cn=,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e66:
+            (num, _) = e66.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # Rename
@@ -1226,7 +1292,8 @@ class BasicTests(samba.tests.TestCase):
             self.ldb.rename("cn=ldaptestgroup,cn=users," + self.base_dn,
                             "=,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e67:
+            (num, _) = e67.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # new empty RDN name
@@ -1234,7 +1301,8 @@ class BasicTests(samba.tests.TestCase):
             self.ldb.rename("cn=ldaptestgroup,cn=users," + self.base_dn,
                             "=ldaptestgroup,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e68:
+            (num, _) = e68.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # new empty RDN value
@@ -1242,7 +1310,8 @@ class BasicTests(samba.tests.TestCase):
             self.ldb.rename("cn=ldaptestgroup,cn=users," + self.base_dn,
                             "cn=,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e69:
+            (num, _) = e69.args
             self.assertEquals(num, ERR_NAMING_VIOLATION)
 
         # new wrong RDN candidate
@@ -1250,7 +1319,8 @@ class BasicTests(samba.tests.TestCase):
             self.ldb.rename("cn=ldaptestgroup,cn=users," + self.base_dn,
                             "description=xyz,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e70:
+            (num, _) = e70.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "description=xyz,cn=users," + self.base_dn)
@@ -1260,7 +1330,8 @@ class BasicTests(samba.tests.TestCase):
             self.ldb.rename("cn=,cn=users," + self.base_dn,
                             "cn=ldaptestgroup,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e71:
+            (num, _) = e71.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         # names
@@ -1272,7 +1343,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e72:
+            (num, _) = e72.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_RDN)
 
         m = Message()
@@ -1282,7 +1354,8 @@ class BasicTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e73:
+            (num, _) = e73.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_RDN)
 
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
@@ -1310,7 +1383,8 @@ objectClass: container
 """
             self.ldb.add_ldif(ldif)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e74:
+            (num, _) = e74.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         delete_force(self.ldb, "%s,%s" % (rdn, self.base_dn))
 
@@ -1320,14 +1394,16 @@ objectClass: container
             # cannot rename to be a child of itself
             ldb.rename(self.base_dn, "dc=test," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e75:
+            (num, _) = e75.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
             # inexistent object
             ldb.rename("cn=ldaptestuser2,cn=users," + self.base_dn, "cn=ldaptestuser2,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e76:
+            (num, _) = e76.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         self.ldb.add({
@@ -1342,28 +1418,32 @@ objectClass: container
             # containment problem: a user entry cannot contain user entries
             ldb.rename("cn=ldaptestuser3,cn=users," + self.base_dn, "cn=ldaptestuser4,cn=ldaptestuser3,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e77:
+            (num, _) = e77.args
             self.assertEquals(num, ERR_NAMING_VIOLATION)
 
         try:
             # invalid parent
             ldb.rename("cn=ldaptestuser3,cn=users," + self.base_dn, "cn=ldaptestuser3,cn=people,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e78:
+            (num, _) = e78.args
             self.assertEquals(num, ERR_OTHER)
 
         try:
             # invalid target DN syntax
             ldb.rename("cn=ldaptestuser3,cn=users," + self.base_dn, ",cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e79:
+            (num, _) = e79.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         try:
             # invalid RDN name
             ldb.rename("cn=ldaptestuser3,cn=users," + self.base_dn, "ou=ldaptestuser3,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e80:
+            (num, _) = e80.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "cn=ldaptestuser3,cn=users," + self.base_dn)
@@ -1374,21 +1454,24 @@ objectClass: container
         try:
             ldb.rename("CN=DisplaySpecifiers," + self.configuration_dn, "CN=DisplaySpecifiers,CN=Services," + self.configuration_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e81:
+            (num, _) = e81.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Limited move failing since no "SYSTEM_FLAG_CONFIG_ALLOW_LIMITED_MOVE"
         try:
             ldb.rename("CN=Directory Service,CN=Windows NT,CN=Services," + self.configuration_dn, "CN=Directory Service,CN=RRAS,CN=Services," + self.configuration_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e82:
+            (num, _) = e82.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Rename failing since no "SYSTEM_FLAG_CONFIG_ALLOW_RENAME"
         try:
             ldb.rename("CN=DisplaySpecifiers," + self.configuration_dn, "CN=DisplaySpecifiers2," + self.configuration_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e83:
+            (num, _) = e83.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # It's not really possible to test moves on the schema partition since
@@ -1398,21 +1481,24 @@ objectClass: container
         try:
             ldb.rename("CN=Top," + self.schema_dn, "CN=Top2," + self.schema_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e84:
+            (num, _) = e84.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Move failing since "SYSTEM_FLAG_DOMAIN_DISALLOW_MOVE"
         try:
             ldb.rename("CN=Users," + self.base_dn, "CN=Users,CN=Computers," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e85:
+            (num, _) = e85.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Rename failing since "SYSTEM_FLAG_DOMAIN_DISALLOW_RENAME"
         try:
             ldb.rename("CN=Users," + self.base_dn, "CN=Users2," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e86:
+            (num, _) = e86.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Performs some other constraints testing
@@ -1420,7 +1506,8 @@ objectClass: container
         try:
             ldb.rename("CN=Policies,CN=System," + self.base_dn, "CN=Users2," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e87:
+            (num, _) = e87.args
             self.assertEquals(num, ERR_OTHER)
 
     def test_rename_twice(self):
@@ -1451,7 +1538,8 @@ objectClass: container
 objectGUID: bd3480c9-58af-4cd8-92df-bc4a18b6e44d
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e88:
+            (num, _) = e88.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         self.ldb.add({
@@ -1467,7 +1555,8 @@ replace: objectGUID
 objectGUID: bd3480c9-58af-4cd8-92df-bc4a18b6e44d
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e89:
+            (num, _) = e89.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         delete_force(self.ldb, "cn=ldaptestcontainer," + self.base_dn)
@@ -1726,7 +1815,8 @@ delete: description
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectclass": "user",
                 "memberOf": "cn=ldaptestgroup,cn=users," + self.base_dn})
-        except LdbError, (num, _):
+        except LdbError as e90:
+            (num, _) = e90.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         ldb.add({
@@ -1740,7 +1830,8 @@ delete: description
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e91:
+            (num, _) = e91.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -1756,7 +1847,8 @@ delete: description
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e92:
+            (num, _) = e92.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -1766,7 +1858,8 @@ delete: description
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e93:
+            (num, _) = e93.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -1862,7 +1955,8 @@ delete: description
                      "cn": "LDAPtest2COMPUTER"
                      })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e94:
+            (num, _) = e94.args
             self.assertEquals(num, ERR_INVALID_DN_SYNTAX)
 
         try:
@@ -1872,7 +1966,8 @@ delete: description
                      "sAMAccountType": str(ATYPE_NORMAL_ACCOUNT)
                 })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e95:
+            (num, _) = e95.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         ldb.add({"dn": "cn=ldaptestcomputer3,cn=computers," + self.base_dn,
@@ -1912,7 +2007,8 @@ servicePrincipalName: host/ldaptest2computer
 servicePrincipalName: cifs/ldaptest2computer
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e96:
+            (num, msg) = e96.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         ldb.modify_ldif("""
@@ -1930,7 +2026,8 @@ add: servicePrincipalName
 servicePrincipalName: host/ldaptest2computer
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e97:
+            (num, msg) = e97.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         # Testing ranged results
@@ -2164,7 +2261,8 @@ servicePrincipalName: host/ldaptest2computer29
                       "objectClass": "user",
                       "cn": "LDAPtestUSER3"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e98:
+            (num, _) = e98.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # rename back
@@ -2175,7 +2273,8 @@ servicePrincipalName: host/ldaptest2computer29
             ldb.rename("cn=ldaptestuser3,cn=users," + self.base_dn,
                        "cn=ldaptestuser2,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e99:
+            (num, _) = e99.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # ensure can now use that name
@@ -2187,12 +2286,14 @@ servicePrincipalName: host/ldaptest2computer29
         try:
             ldb.rename("cn=ldaptestuser2,cn=users," + self.base_dn, "cn=ldaptestuser3,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e100:
+            (num, _) = e100.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
         try:
             ldb.rename("cn=ldaptestuser3,cn=users,%s" % self.base_dn, "cn=ldaptestuser3,%s" % ldb.get_config_basedn())
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e101:
+            (num, _) = e101.args
             self.assertTrue(num in (71, 64))
 
         ldb.rename("cn=ldaptestuser3,cn=users," + self.base_dn, "cn=ldaptestuser5,cn=users," + self.base_dn)
@@ -2243,7 +2344,8 @@ member: cn=ldaptestuser2,cn=users,""" + self.base_dn + """
                     expression="(&(cn=ldaptestuser4)(objectClass=user))",
                     scope=SCOPE_SUBTREE)
             self.fail(res)
-        except LdbError, (num, _):
+        except LdbError as e102:
+            (num, _) = e102.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # Testing one-level ldb.search for (&(cn=ldaptestuser4)(objectClass=user)) in (just renamed from) cn=ldaptestcontainer," + self.base_dn
@@ -2251,7 +2353,8 @@ member: cn=ldaptestuser2,cn=users,""" + self.base_dn + """
             res = ldb.search("cn=ldaptestcontainer," + self.base_dn,
                     expression="(&(cn=ldaptestuser4)(objectClass=user))", scope=SCOPE_ONELEVEL)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e103:
+            (num, _) = e103.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # Testing ldb.search for (&(cn=ldaptestuser4)(objectClass=user)) in renamed container"
@@ -2271,21 +2374,24 @@ member: cn=ldaptestuser2,cn=users,""" + self.base_dn + """
         try:
             ldb.rename("cn=ldaptestcontainer2," + self.base_dn, "cn=ldaptestcontainer,cn=ldaptestcontainer2," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e104:
+            (num, _) = e104.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Testing ldb.rename (into non-existent container) of cn=ldaptestcontainer2," + self.base_dn + " to cn=ldaptestcontainer,cn=ldaptestcontainer3," + self.base_dn
         try:
             ldb.rename("cn=ldaptestcontainer2," + self.base_dn, "cn=ldaptestcontainer,cn=ldaptestcontainer3," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e105:
+            (num, _) = e105.args
             self.assertTrue(num in (ERR_UNWILLING_TO_PERFORM, ERR_OTHER))
 
         # Testing delete (should fail, not a leaf node) of renamed cn=ldaptestcontainer2," + self.base_dn
         try:
             ldb.delete("cn=ldaptestcontainer2," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e106:
+            (num, _) = e106.args
             self.assertEquals(num, ERR_NOT_ALLOWED_ON_NON_LEAF)
 
         # Testing base ldb.search for CN=ldaptestuser4,CN=ldaptestcontainer2," + self.base_dn
@@ -2717,7 +2823,8 @@ objectClass: posixAccount"""% (self.base_dn))
                            "sAMAccountName": user_name,
                            "nTSecurityDescriptor": [] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e107:
+            (num, _) = e107.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         finally:
             delete_force(self.ldb, user_dn)
@@ -2803,7 +2910,8 @@ nTSecurityDescriptor:: """ + desc_base64)
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e108:
+            (num, _) = e108.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -2813,7 +2921,8 @@ nTSecurityDescriptor:: """ + desc_base64)
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e109:
+            (num, _) = e109.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -2823,7 +2932,8 @@ nTSecurityDescriptor:: """ + desc_base64)
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e110:
+            (num, _) = e110.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, user_dn)
@@ -2962,7 +3072,8 @@ nTSecurityDescriptor:: """ + desc_base64
                     try:
                         self.ldb.set_dsheuristics(dshstr + "x")
                         self.fail()
-                    except LdbError, (num, _):
+                    except LdbError as e:
+                        (num, _) = e.args
                         self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
                     dshstr = dshstr + str(i)
                 else:

--- a/source4/dsdb/tests/python/ldap_schema.py
+++ b/source4/dsdb/tests/python/ldap_schema.py
@@ -166,7 +166,8 @@ systemOnly: FALSE
         try:
                  self.ldb.add_ldif(ldif)
                  self.fail()
-        except LdbError, (num, _):
+        except LdbError as e1:
+                 (num, _) = e1.args
                  self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         ldif = """
@@ -342,7 +343,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add duplicate attributeID value")
-        except LdbError, (enum, estr):
+        except LdbError as e2:
+            (enum, estr) = e2.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
 
@@ -386,7 +388,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add duplicate governsID conflicting with attributeID value")
-        except LdbError, (enum, estr):
+        except LdbError as e3:
+            (enum, estr) = e3.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
 
@@ -429,7 +432,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add attribute with duplicate CN")
-        except LdbError, (enum, estr):
+        except LdbError as e4:
+            (enum, estr) = e4.args
             self.assertEquals(enum, ERR_ENTRY_ALREADY_EXISTS)
 
     def test_duplicate_implicit_ldapdisplayname(self):
@@ -472,7 +476,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add attribute with duplicate of the implicit ldapDisplayName")
-        except LdbError, (enum, estr):
+        except LdbError as e5:
+            (enum, estr) = e5.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
 
@@ -517,7 +522,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add attribute with duplicate ldapDisplayName")
-        except LdbError, (enum, estr):
+        except LdbError as e6:
+            (enum, estr) = e6.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
 
@@ -565,7 +571,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add class with duplicate ldapDisplayName")
-        except LdbError, (enum, estr):
+        except LdbError as e7:
+            (enum, estr) = e7.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
 
@@ -619,7 +626,8 @@ ldapDisplayName: """ + attr_ldap_display_name + """
         try:
             self.ldb.modify_ldif(ldif)
             self.fail("Should have failed to modify schema to have attribute with duplicate ldapDisplayName")
-        except LdbError, (enum, estr):
+        except LdbError as e8:
+            (enum, estr) = e8.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
 
@@ -673,7 +681,8 @@ attributeId: """ + attributeID + """
         try:
             self.ldb.modify_ldif(ldif)
             self.fail("Should have failed to modify schema to have attribute with duplicate attributeID")
-        except LdbError, (enum, estr):
+        except LdbError as e9:
+            (enum, estr) = e9.args
             self.assertEquals(enum, ERR_CONSTRAINT_VIOLATION)
 
     def test_remove_ldapdisplayname(self):
@@ -708,7 +717,8 @@ replace: ldapDisplayName
         try:
             self.ldb.modify_ldif(ldif)
             self.fail("Should have failed to remove the ldapdisplayname")
-        except LdbError, (enum, estr):
+        except LdbError as e10:
+            (enum, estr) = e10.args
             self.assertEquals(enum, ERR_OBJECT_CLASS_VIOLATION)
 
     def test_rename_ldapdisplayname(self):
@@ -777,7 +787,8 @@ attributeId: """ + attributeID + """.1
         try:
             self.ldb.modify_ldif(ldif)
             self.fail("Should have failed to modify schema to have different attributeID")
-        except LdbError, (enum, estr):
+        except LdbError as e11:
+            (enum, estr) = e11.args
             self.assertEquals(enum, ERR_CONSTRAINT_VIOLATION)
 
 
@@ -814,7 +825,8 @@ attributeId: """ + attributeID + """
         try:
             self.ldb.modify_ldif(ldif)
             self.fail("Should have failed to modify schema to have the same attributeID")
-        except LdbError, (enum, estr):
+        except LdbError as e12:
+            (enum, estr) = e12.args
             self.assertEquals(enum, ERR_CONSTRAINT_VIOLATION)
 
 
@@ -860,7 +872,8 @@ systemOnly: FALSE
 
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (enum, estr):
+        except LdbError as e13:
+            (enum, estr) = e13.args
             self.fail(estr)
 
         attr_name_2 = "test-generated-linkID-2" + time.strftime("%s", time.gmtime()) + "-" + rand
@@ -885,7 +898,8 @@ systemOnly: FALSE
 
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (enum, estr):
+        except LdbError as e14:
+            (enum, estr) = e14.args
             self.fail(estr)
 
         res = self.ldb.search("CN=%s,%s" % (attr_name_1, self.schema_dn),
@@ -946,7 +960,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add duplicate linkID value")
-        except LdbError, (enum, estr):
+        except LdbError as e15:
+            (enum, estr) = e15.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
         # If we add another attribute with the attributeID or lDAPDisplayName
@@ -974,7 +989,8 @@ systemOnly: FALSE
 
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (enum, estr):
+        except LdbError as e16:
+            (enum, estr) = e16.args
             self.fail(estr)
 
         res = self.ldb.search("CN=%s,%s" % (attr_name_3, self.schema_dn),
@@ -1006,7 +1022,8 @@ systemOnly: FALSE
 
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (enum, estr):
+        except LdbError as e17:
+            (enum, estr) = e17.args
             self.fail(estr)
 
         res = self.ldb.search("CN=%s,%s" % (attr_name_4, self.schema_dn),
@@ -1042,7 +1059,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add duplicate backlink")
-        except LdbError, (enum, estr):
+        except LdbError as e18:
+            (enum, estr) = e18.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
         # If we try to supply the attributeID or ldapDisplayName
@@ -1072,7 +1090,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add backlink of backlink")
-        except LdbError, (enum, estr):
+        except LdbError as e19:
+            (enum, estr) = e19.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
         attr_name = "test-generated-linkID-backlink-invalid-2" + time.strftime("%s", time.gmtime()) + "-" + rand
@@ -1098,7 +1117,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add backlink of backlink")
-        except LdbError, (enum, estr):
+        except LdbError as e20:
+            (enum, estr) = e20.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
     def test_generated_mAPIID(self):
@@ -1133,7 +1153,8 @@ systemOnly: FALSE
 
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (enum, estr):
+        except LdbError as e21:
+            (enum, estr) = e21.args
             self.fail(estr)
 
         res = self.ldb.search("CN=%s,%s" % (attr_name_1, self.schema_dn),
@@ -1174,7 +1195,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif)
             self.fail("Should have failed to add duplicate mAPIID value")
-        except LdbError, (enum, estr):
+        except LdbError as e22:
+            (enum, estr) = e22.args
             self.assertEquals(enum, ERR_UNWILLING_TO_PERFORM)
 
 
@@ -1212,7 +1234,8 @@ governsId: """ + governsID + """.1
         try:
             self.ldb.modify_ldif(ldif)
             self.fail("Should have failed to modify schema to have different governsID")
-        except LdbError, (enum, estr):
+        except LdbError as e23:
+            (enum, estr) = e23.args
             self.assertEquals(enum, ERR_CONSTRAINT_VIOLATION)
 
 
@@ -1250,7 +1273,8 @@ governsId: """ + governsID + """.1
         try:
             self.ldb.modify_ldif(ldif)
             self.fail("Should have failed to modify schema to have the same governsID")
-        except LdbError, (enum, estr):
+        except LdbError as e24:
+            (enum, estr) = e24.args
             self.assertEquals(enum, ERR_CONSTRAINT_VIOLATION)
 
 
@@ -1391,7 +1415,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif_fail)
             self.fail("Adding attribute with preset msDS-IntId should fail")
-        except LdbError, (num, _):
+        except LdbError as e25:
+            (num, _) = e25.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # add the new attribute and update schema
@@ -1418,7 +1443,8 @@ systemOnly: FALSE
         try:
             self.ldb.modify(msg)
             self.fail("Modifying msDS-IntId should return error")
-        except LdbError, (num, _):
+        except LdbError as e26:
+            (num, _) = e26.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # 2. Create attribute with systemFlags = FLAG_SCHEMA_BASE_OBJECT
@@ -1434,7 +1460,8 @@ systemOnly: FALSE
         try:
             self.ldb.add_ldif(ldif_fail)
             self.fail("Adding attribute with preset msDS-IntId should fail")
-        except LdbError, (num, _):
+        except LdbError as e27:
+            (num, _) = e27.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # add the new attribute and update schema
@@ -1461,7 +1488,8 @@ systemOnly: FALSE
         try:
             self.ldb.modify(msg)
             self.fail("Modifying msDS-IntId should return error")
-        except LdbError, (num, _):
+        except LdbError as e28:
+            (num, _) = e28.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
 
@@ -1521,7 +1549,8 @@ systemOnly: FALSE
         try:
             self.ldb.modify(msg)
             self.fail("Modifying msDS-IntId should return error")
-        except LdbError, (num, _):
+        except LdbError as e29:
+            (num, _) = e29.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # 2. Create Class with systemFlags = FLAG_SCHEMA_BASE_OBJECT
@@ -1559,7 +1588,8 @@ systemOnly: FALSE
         try:
             self.ldb.modify(msg)
             self.fail("Modifying msDS-IntId should return error")
-        except LdbError, (num, _):
+        except LdbError as e30:
+            (num, _) = e30.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         res = self.ldb.search(class_dn, scope=SCOPE_BASE, attrs=["msDS-IntId"])
         self.assertEquals(len(res), 1)
@@ -1613,7 +1643,8 @@ class SchemaTests_msDS_isRODC(samba.tests.TestCase):
             ntds_search_dn = "CN=NTDS Settings,%s" % ldb_msg['dn']
             try:
                 res_check = self.ldb.search(ntds_search_dn, attrs=["objectCategory"])
-            except LdbError, (num, _):
+            except LdbError as e:
+                (num, _) = e.args
                 self.assertEquals(num, ERR_NO_SUCH_OBJECT)
                 print("Server entry %s doesn't have a NTDS settings object" % res[0]['dn'])
             else:

--- a/source4/dsdb/tests/python/ldap_syntaxes.py
+++ b/source4/dsdb/tests/python/ldap_syntaxes.py
@@ -222,7 +222,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:ABCD:" + self.base_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e:
+            (num, _) = e.args
             self.assertEquals(num, ERR_INVALID_ATTRIBUTE_SYNTAX)
 
         # add object with the same dn but with different string value in case
@@ -230,7 +231,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:abcde:" + self.base_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e1:
+            (num, _) = e1.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # add object with the same dn but with different string value
@@ -238,7 +240,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:FGHIJ:" + self.base_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e2:
+            (num, _) = e2.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # add object with the same dn but with different dn and string value
@@ -246,7 +249,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:FGHIJ:" + self.schema_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e3:
+            (num, _) = e3.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # add object with the same dn but with different dn value
@@ -254,7 +258,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:ABCDE:" + self.schema_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e4:
+            (num, _) = e4.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # add object with GUID instead of DN
@@ -263,7 +268,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:ABCDE:<GUID=%s>" % str(uuid.uuid4()))
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e5:
+            (num, _) = e5.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # add object with SID instead of DN
@@ -272,7 +278,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:ABCDE:<SID=%s>" % self.ldb.get_domain_sid())
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e6:
+            (num, _) = e6.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # add object with random string instead of DN
@@ -281,7 +288,8 @@ name: """ + object_name + """
                                self.dn_string_attribute, ": S:5:ABCDE:randomSTRING")
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e7:
+            (num, _) = e7.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
     def test_dn_binary(self):
@@ -315,7 +323,8 @@ name: """ + object_name + """
                                self.dn_binary_attribute, ": B:5:67890:" + self.base_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e8:
+            (num, _) = e8.args
             self.assertEquals(num, ERR_INVALID_ATTRIBUTE_SYNTAX)
 
         # add object with the same dn but with different binary value
@@ -323,7 +332,8 @@ name: """ + object_name + """
                                self.dn_binary_attribute, ": B:4:5678:" + self.base_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e9:
+            (num, _) = e9.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # add object with the same dn but with different binary and dn value
@@ -331,7 +341,8 @@ name: """ + object_name + """
                                self.dn_binary_attribute, ": B:4:5678:" + self.schema_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e10:
+            (num, _) = e10.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # add object with the same dn but with different dn value
@@ -339,7 +350,8 @@ name: """ + object_name + """
                                self.dn_binary_attribute, ": B:4:1234:" + self.schema_dn)
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e11:
+            (num, _) = e11.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # add object with GUID instead of DN
@@ -348,7 +360,8 @@ name: """ + object_name + """
                                self.dn_binary_attribute, ": B:4:1234:<GUID=%s>" % str(uuid.uuid4()))
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e12:
+            (num, _) = e12.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # add object with SID instead of DN
@@ -357,7 +370,8 @@ name: """ + object_name + """
                                self.dn_binary_attribute, ": B:4:1234:<SID=%s>" % self.ldb.get_domain_sid())
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e13:
+            (num, _) = e13.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # add object with random string instead of DN
@@ -366,7 +380,8 @@ name: """ + object_name + """
                                self.dn_binary_attribute, ": B:4:1234:randomSTRING")
         try:
             self.ldb.add_ldif(ldif)
-        except LdbError, (num, _):
+        except LdbError as e14:
+            (num, _) = e14.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
 TestProgram(module=__name__, opts=subunitopts)

--- a/source4/dsdb/tests/python/linked_attributes.py
+++ b/source4/dsdb/tests/python/linked_attributes.py
@@ -169,7 +169,8 @@ class LATests(samba.tests.TestCase):
         """Assert a function raises a particular LdbError."""
         try:
             f(*args, **kwargs)
-        except ldb.LdbError as (num, msg):
+        except ldb.LdbError as e:
+            (num, msg) = e.args
             if num != errcode:
                 lut = {v: k for k, v in vars(ldb).iteritems()
                        if k.startswith('ERR_') and isinstance(v, int)}

--- a/source4/dsdb/tests/python/notification.py
+++ b/source4/dsdb/tests/python/notification.py
@@ -143,7 +143,8 @@ otherLoginWorkstations: AFTER"
         try:
             res = notify1.result()
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e10:
+            (num, _) = e10.args
             self.assertEquals(num, ERR_TIME_LIMIT_EXCEEDED)
         self.assertIsNotNone(msg3)
 
@@ -176,7 +177,8 @@ delete: otherLoginWorkstations
                     continue
                 res = notifies[i].result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e:
+                (num, _) = e.args
                 if num == ERR_ADMIN_LIMIT_EXCEEDED:
                     num_admin_limit += 1
                     continue
@@ -206,7 +208,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e1:
+                (num, _) = e1.args
                 self.assertEquals(num, ERR_TIME_LIMIT_EXCEEDED)
 
             try:
@@ -220,7 +223,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e2:
+                (num, _) = e2.args
                 self.assertEquals(num, ERR_TIME_LIMIT_EXCEEDED)
 
             try:
@@ -234,7 +238,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e3:
+                (num, _) = e3.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
             try:
@@ -248,7 +253,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e4:
+                (num, _) = e4.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
             try:
@@ -262,7 +268,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e5:
+                (num, _) = e5.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
             try:
@@ -276,7 +283,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e6:
+                (num, _) = e6.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
             try:
@@ -290,7 +298,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e7:
+                (num, _) = e7.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
             try:
@@ -304,7 +313,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e8:
+                (num, _) = e8.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         res = self.ldb.search(base=self.ldb.get_schema_basedn(),
@@ -328,7 +338,8 @@ delete: otherLoginWorkstations
                     self.fail()
                 res = hnd.result()
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e9:
+                (num, _) = e9.args
                 if num != ERR_UNWILLING_TO_PERFORM:
                     print "va[%s]" % va
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
@@ -345,7 +356,8 @@ delete: otherLoginWorkstations
                 self.fail()
             res = hnd.result()
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e11:
+            (num, _) = e11.args
             if num != ERR_UNWILLING_TO_PERFORM:
                 print "va[%s]" % va
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)

--- a/source4/dsdb/tests/python/password_lockout.py
+++ b/source4/dsdb/tests/python/password_lockout.py
@@ -169,7 +169,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e:
+            (num, msg) = e.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -215,7 +216,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e1:
+            (num, msg) = e1.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -243,7 +245,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e2:
+            (num, msg) = e2.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -271,7 +274,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e3:
+            (num, msg) = e3.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -297,7 +301,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e4:
+            (num, msg) = e4.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -323,7 +328,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2x
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e5:
+            (num, msg) = e5.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -368,7 +374,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2x
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e6:
+            (num, msg) = e6.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -415,7 +422,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2x\"".encode('utf-16-le')) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e7:
+            (num, msg) = e7.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -479,7 +487,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2XYZ
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e8:
+            (num, msg) = e8.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -506,7 +515,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2XYZ
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e9:
+            (num, msg) = e9.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -608,7 +618,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e10:
+            (num, msg) = e10.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -660,7 +671,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(new_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e11:
+            (num, msg) = e11.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -703,7 +715,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(new_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e12:
+            (num, msg) = e12.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -732,7 +745,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(new_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e13:
+            (num, msg) = e13.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -758,7 +772,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(new_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e14:
+            (num, msg) = e14.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -784,7 +799,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e15:
+            (num, msg) = e15.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000775' in msg, msg)
 
@@ -851,7 +867,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(new_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e16:
+            (num, msg) = e16.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -878,7 +895,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(new_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e17:
+            (num, msg) = e17.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -920,7 +938,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode(new_utf16) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e18:
+            (num, msg) = e18.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg, msg)
 
@@ -1053,7 +1072,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e19:
+            (num, msg) = e19.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             # Windows (2008 at least) seems to have some small bug here: it
             # returns "0000056A" on longer (always wrong) previous passwords.

--- a/source4/dsdb/tests/python/password_lockout_base.py
+++ b/source4/dsdb/tests/python/password_lockout_base.py
@@ -236,7 +236,8 @@ userPassword: """ + userpass + """
         try:
             ldb = SamDB(url=self.host_url, credentials=fail_creds, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e:
+            (num, msg) = e.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         # Succeed to reset everything to 0
@@ -248,7 +249,8 @@ userPassword: """ + userpass + """
         try:
             ldb = SamDB(url=url, credentials=creds, lp=lp)
             self.fail("Login unexpectedly succeeded")
-        except LdbError, (num, msg):
+        except LdbError as e1:
+            (num, msg) = e1.args
             if errno is not None:
                 self.assertEquals(num, errno, ("Login failed in the wrong way"
                                                "(got err %d, expected %d)" %
@@ -479,7 +481,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
 
-        except LdbError, (num, msg):
+        except LdbError as e2:
+            (num, msg) = e2.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -502,7 +505,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
 
-        except LdbError, (num, msg):
+        except LdbError as e3:
+            (num, msg) = e3.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -523,7 +527,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e4:
+            (num, msg) = e4.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -542,7 +547,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e5:
+            (num, msg) = e5.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -561,7 +567,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e6:
+            (num, msg) = e6.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -619,7 +626,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e7:
+            (num, msg) = e7.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -639,7 +647,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e8:
+            (num, msg) = e8.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -672,7 +681,8 @@ lockoutThreshold: """ + str(lockoutThreshold) + """
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e9:
+            (num, msg) = e9.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,

--- a/source4/dsdb/tests/python/passwords.py
+++ b/source4/dsdb/tests/python/passwords.py
@@ -113,7 +113,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e:
+            (num, msg) = e.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             # Windows (2008 at least) seems to have some small bug here: it
             # returns "0000056A" on longer (always wrong) previous passwords.
@@ -141,7 +142,8 @@ userPassword: thatsAcomplPASS1
 add: userPassword
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e1:
+            (num, _) = e1.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # Enables the user account
@@ -171,7 +173,8 @@ add: userPassword
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e2:
+            (num, _) = e2.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
     def test_unicodePwd_hash_change(self):
@@ -189,7 +192,8 @@ add: unicodePwd
 unicodePwd: YYYYYYYYYYYYYYYY
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e3:
+            (num, _) = e3.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
     def test_unicodePwd_clear_set(self):
@@ -224,7 +228,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS4\"".encode('utf-16-le')) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e4:
+            (num, msg) = e4.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg)
 
@@ -239,7 +244,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e5:
+            (num, msg) = e5.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('0000052D' in msg)
 
@@ -254,7 +260,8 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) 
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e6:
+            (num, _) = e6.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
     def test_dBCSPwd_hash_change(self):
@@ -271,7 +278,8 @@ add: dBCSPwd
 dBCSPwd: YYYYYYYYYYYYYYYY
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e7:
+            (num, _) = e7.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
     def test_userPassword_clear_set(self):
@@ -310,7 +318,8 @@ add: userPassword
 userPassword: thatsAcomplPASS4
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e8:
+            (num, msg) = e8.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('00000056' in msg)
 
@@ -325,7 +334,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e9:
+            (num, msg) = e9.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
             self.assertTrue('0000052D' in msg)
 
@@ -340,7 +350,8 @@ userPassword: thatsAcomplPASS2
               FLAG_MOD_REPLACE, "clearTextPassword")
             self.ldb.modify(m)
             # this passes against s4
-        except LdbError, (num, msg):
+        except LdbError as e10:
+            (num, msg) = e10.args
             # "NO_SUCH_ATTRIBUTE" is returned by Windows -> ignore it
             if num != ERR_NO_SUCH_ATTRIBUTE:
                 raise LdbError(num, msg)
@@ -359,7 +370,8 @@ add: clearTextPassword
 clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')) + """
 """)
             # this passes against s4
-        except LdbError, (num, msg):
+        except LdbError as e11:
+            (num, msg) = e11.args
             # "NO_SUCH_ATTRIBUTE" is returned by Windows -> ignore it
             if num != ERR_NO_SUCH_ATTRIBUTE:
                 raise LdbError(num, msg)
@@ -375,7 +387,8 @@ add: clearTextPassword
 clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS4".encode('utf-16-le')) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e12:
+            (num, msg) = e12.args
             # "NO_SUCH_ATTRIBUTE" is returned by Windows -> ignore it
             if num != ERR_NO_SUCH_ATTRIBUTE:
                 self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
@@ -392,7 +405,8 @@ add: clearTextPassword
 clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')) + """
 """)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e13:
+            (num, msg) = e13.args
             # "NO_SUCH_ATTRIBUTE" is returned by Windows -> ignore it
             if num != ERR_NO_SUCH_ATTRIBUTE:
                 self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
@@ -409,7 +423,8 @@ delete: userPassword
 userPassword: thatsAcomplPASS1
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e14:
+            (num, _) = e14.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -420,7 +435,8 @@ delete: userPassword
 userPassword: thatsAcomplPASS1
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e15:
+            (num, _) = e15.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -430,7 +446,8 @@ changetype: modify
 delete: userPassword
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e16:
+            (num, _) = e16.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -440,7 +457,8 @@ changetype: modify
 delete: userPassword
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e17:
+            (num, _) = e17.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -451,7 +469,8 @@ add: userPassword
 userPassword: thatsAcomplPASS1
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e18:
+            (num, _) = e18.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -462,7 +481,8 @@ add: userPassword
 userPassword: thatsAcomplPASS1
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e19:
+            (num, _) = e19.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         try:
@@ -476,7 +496,8 @@ userPassword: thatsAcomplPASS2
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e20:
+            (num, _) = e20.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -490,7 +511,8 @@ userPassword: thatsAcomplPASS2
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e21:
+            (num, _) = e21.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -504,7 +526,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e22:
+            (num, _) = e22.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -518,7 +541,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e23:
+            (num, _) = e23.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -533,7 +557,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e24:
+            (num, _) = e24.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -548,7 +573,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e25:
+            (num, _) = e25.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         try:
@@ -563,7 +589,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e26:
+            (num, _) = e26.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -578,7 +605,8 @@ add: userPassword
 userPassword: thatsAcomplPASS2
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e27:
+            (num, _) = e27.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         try:
@@ -593,7 +621,8 @@ replace: userPassword
 userPassword: thatsAcomplPASS3
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e28:
+            (num, _) = e28.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -608,7 +637,8 @@ replace: userPassword
 userPassword: thatsAcomplPASS3
 """)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e29:
+            (num, _) = e29.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         # Reverse order does work
@@ -631,7 +661,8 @@ add: unicodePwd
 unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')) + """
 """)
              # this passes against s4
-        except LdbError, (num, _):
+        except LdbError as e30:
+            (num, _) = e30.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         try:
@@ -644,7 +675,8 @@ add: userPassword
 userPassword: thatsAcomplPASS4
 """)
              # this passes against s4
-        except LdbError, (num, _):
+        except LdbError as e31:
+            (num, _) = e31.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         # Several password changes at once are allowed
@@ -692,7 +724,8 @@ userPassword: thatsAcomplPASS4
                  "objectclass": "user",
                  "unicodePwd": [] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e32:
+            (num, _) = e32.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -701,7 +734,8 @@ userPassword: thatsAcomplPASS4
                  "objectclass": "user",
                  "dBCSPwd": [] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e33:
+            (num, _) = e33.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -710,7 +744,8 @@ userPassword: thatsAcomplPASS4
                  "objectclass": "user",
                  "userPassword": [] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e34:
+            (num, _) = e34.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         try:
@@ -719,7 +754,8 @@ userPassword: thatsAcomplPASS4
                  "objectclass": "user",
                  "clearTextPassword": [] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e35:
+            (num, _) = e35.args
             self.assertTrue(num == ERR_CONSTRAINT_VIOLATION or
                             num == ERR_NO_SUCH_ATTRIBUTE) # for Windows
 
@@ -731,7 +767,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e36:
+            (num, _) = e36.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -740,7 +777,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e37:
+            (num, _) = e37.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -749,7 +787,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e38:
+            (num, _) = e38.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -758,7 +797,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e39:
+            (num, _) = e39.args
             self.assertTrue(num == ERR_CONSTRAINT_VIOLATION or
                             num == ERR_NO_SUCH_ATTRIBUTE) # for Windows
 
@@ -768,7 +808,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e40:
+            (num, _) = e40.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -777,7 +818,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e41:
+            (num, _) = e41.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -786,7 +828,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e42:
+            (num, _) = e42.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -795,7 +838,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e43:
+            (num, _) = e43.args
             self.assertTrue(num == ERR_UNWILLING_TO_PERFORM or
                             num == ERR_NO_SUCH_ATTRIBUTE) # for Windows
 
@@ -805,7 +849,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e44:
+            (num, _) = e44.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -814,7 +859,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e45:
+            (num, _) = e45.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -823,7 +869,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e46:
+            (num, _) = e46.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         m = Message()
@@ -832,7 +879,8 @@ userPassword: thatsAcomplPASS4
         try:
             self.ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e47:
+            (num, _) = e47.args
             self.assertTrue(num == ERR_CONSTRAINT_VIOLATION or
                             num == ERR_NO_SUCH_ATTRIBUTE) # for Windows
 

--- a/source4/dsdb/tests/python/rodc.py
+++ b/source4/dsdb/tests/python/rodc.py
@@ -67,7 +67,8 @@ class RodcTests(samba.tests.TestCase):
             try:
                 self.samdb.add(o)
                 self.fail("Failed to fail to add %s" % o['dn'])
-            except ldb.LdbError as (ecode, emsg):
+            except ldb.LdbError as e:
+                (ecode, emsg) = e.args
                 if ecode != ldb.ERR_REFERRAL:
                     print emsg
                     self.fail("Adding %s: ldb error: %s %s, wanted referral" %
@@ -103,7 +104,8 @@ class RodcTests(samba.tests.TestCase):
             try:
                 self.samdb.modify(msg)
                 self.fail("Failed to fail to modify %s %s" % (dn, attr))
-            except ldb.LdbError as (ecode, emsg):
+            except ldb.LdbError as e1:
+                (ecode, emsg) = e1.args
                 if ecode != ldb.ERR_REFERRAL:
                     self.fail("Failed to REFER when trying to modify %s %s" %
                               (dn, attr))
@@ -138,7 +140,8 @@ class RodcTests(samba.tests.TestCase):
             try:
                 self.samdb.modify(m)
                 self.fail("Failed to fail to modify %s %s" % (dn, attr))
-            except ldb.LdbError as (ecode, emsg):
+            except ldb.LdbError as e2:
+                (ecode, emsg) = e2.args
                 if ecode != ldb.ERR_REFERRAL:
                     self.fail("Failed to REFER when trying to modify %s %s" %
                               (dn, attr))
@@ -172,7 +175,8 @@ class RodcTests(samba.tests.TestCase):
         try:
             self.samdb.modify(m)
             self.fail("Failed to fail to modify %s %s" % (dn, attr))
-        except ldb.LdbError as (ecode, emsg):
+        except ldb.LdbError as e3:
+            (ecode, emsg) = e3.args
             if ecode != ldb.ERR_REFERRAL:
                 self.fail("Failed to REFER when trying to modify %s %s" %
                           (dn, attr))
@@ -190,7 +194,8 @@ class RodcTests(samba.tests.TestCase):
         try:
             self.samdb.delete(dn)
             self.fail("Failed to fail to delete %s" % (dn))
-        except ldb.LdbError as (ecode, emsg):
+        except ldb.LdbError as e4:
+            (ecode, emsg) = e4.args
             if ecode != ldb.ERR_REFERRAL:
                 print ecode, emsg
                 self.fail("Failed to REFER when trying to delete %s" % dn)
@@ -208,7 +213,8 @@ class RodcTests(samba.tests.TestCase):
         try:
             self.samdb.delete(dn)
             self.fail("Failed to fail to delete %s" % (dn))
-        except ldb.LdbError as (ecode, emsg):
+        except ldb.LdbError as e5:
+            (ecode, emsg) = e5.args
             if ecode != ldb.ERR_NO_SUCH_OBJECT:
                 print ecode, emsg
                 self.fail("Failed to NO_SUCH_OBJECT when trying to delete "

--- a/source4/dsdb/tests/python/rodc_rwdc.py
+++ b/source4/dsdb/tests/python/rodc_rwdc.py
@@ -471,7 +471,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
 
-        except LdbError, (num, msg):
+        except LdbError as e1:
+            (num, msg) = e1.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -494,7 +495,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
 
-        except LdbError, (num, msg):
+        except LdbError as e2:
+            (num, msg) = e2.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -515,7 +517,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e3:
+            (num, msg) = e3.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -534,7 +537,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e4:
+            (num, msg) = e4.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -553,7 +557,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e5:
+            (num, msg) = e5.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -608,7 +613,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e6:
+            (num, msg) = e6.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -628,7 +634,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e7:
+            (num, msg) = e7.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -661,7 +668,8 @@ class RodcRwdcCachedTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb_lockout = SamDB(url=self.host_url, credentials=creds_lockout, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e8:
+            (num, msg) = e8.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         res = self._check_account(userdn,
@@ -781,7 +789,8 @@ class RodcRwdcTests(password_lockout_base.BasePasswordTestCase):
         try:
             fn(*args, **kwargs)
             self.fail("failed to raise ldap referral")
-        except ldb.LdbError as (code, msg):
+        except ldb.LdbError as e9:
+            (code, msg) = e9.args
             self.assertEqual(code, ldb.ERR_REFERRAL,
                              "expected referral, got %s %s" % (code, msg))
 
@@ -824,7 +833,8 @@ class RodcRwdcTests(password_lockout_base.BasePasswordTestCase):
 
             try:
                 self.rwdc_db.add(o)
-            except ldb.LdbError as (ecode, emsg):
+            except ldb.LdbError as e:
+                (ecode, emsg) = e.args
                 self.fail("Failed to add %s to rwdc: ldb error: %s %s" %
                           (ecode, emsg))
 
@@ -1022,7 +1032,8 @@ class RodcRwdcTests(password_lockout_base.BasePasswordTestCase):
                           session_info=system_session(LP), lp=LP)
             if errno is not None:
                 self.fail("logon failed to fail with ldb error %s" % errno)
-        except ldb.LdbError as (code, msg):
+        except ldb.LdbError as e10:
+            (code, msg) = e10.args
             if code != errno:
                 if errno is None:
                     self.fail("logon incorrectly raised ldb error (code=%s)" %
@@ -1172,7 +1183,8 @@ class RodcRwdcTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb = SamDB(url=self.host_url, credentials=fail_creds, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e11:
+            (num, msg) = e11.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         # Succeed to reset everything to 0
@@ -1201,7 +1213,8 @@ class RodcRwdcTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb = SamDB(url=self.host_url, credentials=fail_creds, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e12:
+            (num, msg) = e12.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         # Succeed to reset everything to 0
@@ -1225,7 +1238,8 @@ class RodcRwdcTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb = SamDB(url=self.host_url, credentials=fail_creds, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e13:
+            (num, msg) = e13.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         # Succeed to reset everything to 0
@@ -1254,7 +1268,8 @@ class RodcRwdcTests(password_lockout_base.BasePasswordTestCase):
         try:
             ldb = SamDB(url=self.host_url, credentials=fail_creds, lp=self.lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e14:
+            (num, msg) = e14.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
 
         # Succeed to reset everything to 0

--- a/source4/dsdb/tests/python/sam.py
+++ b/source4/dsdb/tests/python/sam.py
@@ -120,7 +120,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "sAMAccountName": "administrator"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e9:
+            (num, _) = e9.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -131,7 +132,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "sAMAccountName": []})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e10:
+            (num, _) = e10.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -142,7 +144,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "primaryGroupID": "0"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e11:
+            (num, _) = e11.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -153,7 +156,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "primaryGroupID": str(group_rid_1)})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e12:
+            (num, _) = e12.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -166,7 +170,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e13:
+            (num, _) = e13.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # Test to see how we should behave when the account isn't a user
@@ -177,7 +182,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e14:
+            (num, _) = e14.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
 
         # Test default primary groups on add operations
@@ -332,7 +338,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e15:
+            (num, _) = e15.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # But to reset the actual "sAMAccountName" should still be possible
@@ -367,7 +374,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e16:
+            (num, _) = e16.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Try to make group 1 primary - should be denied since it is not yet
@@ -379,7 +387,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e17:
+            (num, _) = e17.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Make group 1 secondary
@@ -400,7 +409,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.delete("cn=ldaptestgroup,cn=users," + self.base_dn)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e18:
+            (num, _) = e18.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # Try to add group 1 also as secondary - should be denied
@@ -411,7 +421,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e19:
+            (num, _) = e19.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # Try to add invalid member to group 1 - should be denied
@@ -423,7 +434,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e20:
+            (num, _) = e20.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # Make group 2 secondary
@@ -471,7 +483,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e21:
+            (num, _) = e21.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Delete invalid group member
@@ -482,7 +495,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e22:
+            (num, _) = e22.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Also this should be denied
@@ -492,7 +506,8 @@ class SamTests(samba.tests.TestCase):
               "objectclass": "user",
               "primaryGroupID": "0"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e23:
+            (num, _) = e23.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Recreate user accounts
@@ -521,7 +536,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e24:
+            (num, _) = e24.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # Already added, but as <SID=...>
@@ -537,7 +553,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e25:
+            (num, _) = e25.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
         # Invalid member
@@ -548,7 +565,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e26:
+            (num, _) = e26.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # Invalid member
@@ -560,7 +578,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e27:
+            (num, _) = e27.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # Invalid member
@@ -573,7 +592,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e28:
+            (num, _) = e28.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         m = Message()
@@ -612,7 +632,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e29:
+            (num, _) = e29.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         # Delete protection tests
@@ -626,7 +647,8 @@ class SamTests(samba.tests.TestCase):
             try:
                 ldb.modify(m)
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e:
+                (num, _) = e.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
             m = Message()
@@ -635,7 +657,8 @@ class SamTests(samba.tests.TestCase):
             try:
                 ldb.modify(m)
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e1:
+                (num, _) = e1.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -645,7 +668,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e30:
+            (num, _) = e30.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -655,7 +679,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e31:
+            (num, _) = e31.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -665,7 +690,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e32:
+            (num, _) = e32.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -675,7 +701,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e33:
+            (num, _) = e33.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -685,7 +712,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e34:
+            (num, _) = e34.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         # Delete protection tests
@@ -702,7 +730,8 @@ class SamTests(samba.tests.TestCase):
             try:
                 ldb.modify(m)
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e2:
+                (num, _) = e2.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
             m = Message()
@@ -711,7 +740,8 @@ class SamTests(samba.tests.TestCase):
             try:
                 ldb.modify(m)
                 self.fail()
-            except LdbError, (num, _):
+            except LdbError as e3:
+                (num, _) = e3.args
                 self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
@@ -727,7 +757,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "primaryGroupToken": "100"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e35:
+            (num, _) = e35.args
             self.assertEquals(num, ERR_UNDEFINED_ATTRIBUTE_TYPE)
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
 
@@ -785,7 +816,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e36:
+            (num, _) = e36.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
@@ -851,7 +883,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "groupType": "0"})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e37:
+            (num, _) = e37.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
 
@@ -861,7 +894,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "groupType": str(GTYPE_SECURITY_BUILTIN_LOCAL_GROUP)})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e38:
+            (num, _) = e38.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
         delete_force(self.ldb, "cn=ldaptestgroup,cn=users," + self.base_dn)
 
@@ -962,7 +996,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e39:
+            (num, _) = e39.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Security groups
@@ -992,7 +1027,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e40:
+            (num, _) = e40.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Change to "universal"
@@ -1065,7 +1101,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e41:
+            (num, _) = e41.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Change to "builtin local" (shouldn't work)
@@ -1078,7 +1115,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e42:
+            (num, _) = e42.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -1109,7 +1147,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e43:
+            (num, _) = e43.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Change back to "global"
@@ -1137,7 +1176,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e44:
+            (num, _) = e44.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Distribution groups
@@ -1167,7 +1207,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e45:
+            (num, _) = e45.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Change to "universal"
@@ -1240,7 +1281,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e46:
+            (num, _) = e46.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Change back to "universal"
@@ -1254,7 +1296,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e47:
+            (num, _) = e47.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         # Make group 2 secondary
@@ -1314,7 +1357,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e48:
+            (num, _) = e48.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Change to "universal"
@@ -1387,7 +1431,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "groupType")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e49:
+            (num, _) = e49.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # Change back to "universal"
@@ -1465,7 +1510,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "pwdLastSet": str(1)})
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e50:
+            (num, msg) = e50.args
             self.assertEquals(num, ERR_OTHER)
             self.assertTrue('00000057' in msg)
 
@@ -1475,7 +1521,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "pwdLastSet": str(lastset)})
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e51:
+            (num, msg) = e51.args
             self.assertEquals(num, ERR_OTHER)
             self.assertTrue('00000057' in msg)
 
@@ -1538,7 +1585,8 @@ class SamTests(samba.tests.TestCase):
                                        "pwdLastSet")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e52:
+            (num, msg) = e52.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
             self.assertTrue('00002085' in msg)
 
@@ -1553,7 +1601,8 @@ class SamTests(samba.tests.TestCase):
                                        "pwdLastSet")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e53:
+            (num, msg) = e53.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
             self.assertTrue('00002085' in msg)
 
@@ -1588,7 +1637,8 @@ class SamTests(samba.tests.TestCase):
                                        "pwdLastSet")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e54:
+            (num, msg) = e54.args
             self.assertEquals(num, ERR_OTHER)
             self.assertTrue('00000057' in msg)
 
@@ -1737,7 +1787,8 @@ class SamTests(samba.tests.TestCase):
             simple_ldb = SamDB(url=host, credentials=simple_creds, lp=lp)
             self.assertIsNotNone(simple_ldb)
             simple_ldb = None
-        except LdbError, (num, msg):
+        except LdbError as e55:
+            (num, msg) = e55.args
             if num != ERR_STRONG_AUTH_REQUIRED:
                 raise
             requires_strong_auth = True
@@ -1750,7 +1801,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb_fail = SamDB(url=host, credentials=sasl_wrong_creds, lp=lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e56:
+            (num, msg) = e56.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
             self.assertTrue(error_msg_sasl_wrong_pw in msg)
 
@@ -1758,7 +1810,8 @@ class SamTests(samba.tests.TestCase):
             try:
                 ldb_fail = SamDB(url=host, credentials=simple_wrong_creds, lp=lp)
                 self.fail()
-            except LdbError, (num, msg):
+            except LdbError as e4:
+                (num, msg) = e4.args
                 self.assertEquals(num, ERR_INVALID_CREDENTIALS)
                 assertLDAPErrorMsg(msg, error_msg_simple_wrong_pw)
 
@@ -1776,14 +1829,16 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb_fail = SamDB(url=host, credentials=sasl_wrong_creds, lp=lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e57:
+            (num, msg) = e57.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
             assertLDAPErrorMsg(msg, error_msg_sasl_wrong_pw)
 
         try:
             ldb_fail = SamDB(url=host, credentials=sasl_creds, lp=lp)
             self.fail()
-        except LdbError, (num, msg):
+        except LdbError as e58:
+            (num, msg) = e58.args
             self.assertEquals(num, ERR_INVALID_CREDENTIALS)
             assertLDAPErrorMsg(msg, error_msg_sasl_must_change)
 
@@ -1791,14 +1846,16 @@ class SamTests(samba.tests.TestCase):
             try:
                 ldb_fail = SamDB(url=host, credentials=simple_wrong_creds, lp=lp)
                 self.fail()
-            except LdbError, (num, msg):
+            except LdbError as e5:
+                (num, msg) = e5.args
                 self.assertEquals(num, ERR_INVALID_CREDENTIALS)
                 assertLDAPErrorMsg(msg, error_msg_simple_wrong_pw)
 
             try:
                 ldb_fail = SamDB(url=host, credentials=simple_creds, lp=lp)
                 self.fail()
-            except LdbError, (num, msg):
+            except LdbError as e6:
+                (num, msg) = e6.args
                 self.assertEquals(num, ERR_INVALID_CREDENTIALS)
                 assertLDAPErrorMsg(msg, error_msg_simple_must_change)
 
@@ -1874,7 +1931,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "userAccountControl": str(UF_TEMP_DUPLICATE_ACCOUNT)})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e59:
+            (num, _) = e59.args
             self.assertEquals(num, ERR_OTHER)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -1884,7 +1942,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "userAccountControl": str(UF_SERVER_TRUST_ACCOUNT)})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e60:
+            (num, _) = e60.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -1893,7 +1952,8 @@ class SamTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectclass": "user",
                 "userAccountControl": str(UF_WORKSTATION_TRUST_ACCOUNT)})
-        except LdbError, (num, _):
+        except LdbError as e61:
+            (num, _) = e61.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -1902,7 +1962,8 @@ class SamTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestuser,cn=users," + self.base_dn,
                 "objectclass": "user",
                 "userAccountControl": str(UF_WORKSTATION_TRUST_ACCOUNT | UF_PARTIAL_SECRETS_ACCOUNT)})
-        except LdbError, (num, _):
+        except LdbError as e62:
+            (num, _) = e62.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -1912,7 +1973,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "user",
                 "userAccountControl": str(UF_INTERDOMAIN_TRUST_ACCOUNT)})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e63:
+            (num, _) = e63.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         delete_force(self.ldb, "cn=ldaptestuser,cn=users," + self.base_dn)
 
@@ -1944,7 +2006,8 @@ class SamTests(samba.tests.TestCase):
             m["userAccountControl"] = MessageElement("0",
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
-        except LdbError, (num, _):
+        except LdbError as e64:
+            (num, _) = e64.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -1954,7 +2017,8 @@ class SamTests(samba.tests.TestCase):
               str(UF_NORMAL_ACCOUNT),
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
-        except LdbError, (num, _):
+        except LdbError as e65:
+            (num, _) = e65.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -2020,7 +2084,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e66:
+            (num, _) = e66.args
             self.assertEquals(num, ERR_OTHER)
 
         try:
@@ -2031,7 +2096,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e67:
+            (num, _) = e67.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -2049,7 +2115,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e68:
+            (num, _) = e68.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         res1 = ldb.search("cn=ldaptestuser,cn=users," + self.base_dn,
@@ -2079,7 +2146,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e69:
+            (num, _) = e69.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         # With a computer object
@@ -2148,7 +2216,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "computer",
                 "userAccountControl": str(UF_TEMP_DUPLICATE_ACCOUNT)})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e70:
+            (num, _) = e70.args
             self.assertEquals(num, ERR_OTHER)
         delete_force(self.ldb, "cn=ldaptestcomputer,cn=computers," + self.base_dn)
 
@@ -2169,7 +2238,8 @@ class SamTests(samba.tests.TestCase):
                 "dn": "cn=ldaptestcomputer,cn=computers," + self.base_dn,
                 "objectclass": "computer",
                 "userAccountControl": str(UF_WORKSTATION_TRUST_ACCOUNT)})
-        except LdbError, (num, _):
+        except LdbError as e71:
+            (num, _) = e71.args
             self.assertEquals(num, ERR_OBJECT_CLASS_VIOLATION)
         delete_force(self.ldb, "cn=ldaptestcomputer,cn=computers," + self.base_dn)
 
@@ -2179,7 +2249,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "computer",
                 "userAccountControl": str(UF_INTERDOMAIN_TRUST_ACCOUNT)})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e72:
+            (num, _) = e72.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
         delete_force(self.ldb, "cn=ldaptestcomputer,cn=computers," + self.base_dn)
 
@@ -2212,7 +2283,8 @@ class SamTests(samba.tests.TestCase):
             m["userAccountControl"] = MessageElement("0",
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
-        except LdbError, (num, _):
+        except LdbError as e73:
+            (num, _) = e73.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -2222,7 +2294,8 @@ class SamTests(samba.tests.TestCase):
               str(UF_NORMAL_ACCOUNT),
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
-        except LdbError, (num, _):
+        except LdbError as e74:
+            (num, _) = e74.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -2288,7 +2361,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e75:
+            (num, _) = e75.args
             self.assertEquals(num, ERR_OTHER)
 
         m = Message()
@@ -2377,7 +2451,8 @@ class SamTests(samba.tests.TestCase):
               FLAG_MOD_REPLACE, "userAccountControl")
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e76:
+            (num, _) = e76.args
             self.assertEquals(num, ERR_INSUFFICIENT_ACCESS_RIGHTS)
 
         # "primaryGroupID" does not change if account type remains the same
@@ -3299,7 +3374,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e77:
+            (num, _) = e77.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -3379,7 +3455,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e78:
+            (num, _) = e78.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -3434,7 +3511,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e79:
+            (num, _) = e79.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -3444,7 +3522,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e80:
+            (num, _) = e80.args
             self.assertEquals(num, ERR_NO_SUCH_ATTRIBUTE)
 
         m = Message()
@@ -3464,7 +3543,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e81:
+            (num, _) = e81.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -3474,7 +3554,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e82:
+            (num, _) = e82.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
         m = Message()
@@ -3521,7 +3602,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "fSMORoleOwner": self.base_dn})
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e83:
+            (num, _) = e83.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         try:
@@ -3530,7 +3612,8 @@ class SamTests(samba.tests.TestCase):
                 "objectclass": "group",
                 "fSMORoleOwner": [] })
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e84:
+            (num, _) = e84.args
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)
 
         # We are able to set it to a valid "nTDSDSA" entry if the server is
@@ -3553,7 +3636,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e85:
+            (num, _) = e85.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         m = Message()
@@ -3562,7 +3646,8 @@ class SamTests(samba.tests.TestCase):
         try:
             ldb.modify(m)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e86:
+            (num, _) = e86.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
         # We are able to set it to a valid "nTDSDSA" entry if the server is
@@ -3599,7 +3684,8 @@ class SamTests(samba.tests.TestCase):
         for pr_object in protected_list:
             try:
                 self.ldb.delete(pr_object[0] + "," + pr_object[1] + self.base_dn)
-            except LdbError, (num, _):
+            except LdbError as e7:
+                (num, _) = e7.args
                 self.assertEquals(num, ERR_OTHER)
             else:
                 self.fail("Deleted " + pr_object[0])
@@ -3607,7 +3693,8 @@ class SamTests(samba.tests.TestCase):
             try:
                 self.ldb.rename(pr_object[0] + "," + pr_object[1] + self.base_dn,
                                 pr_object[0] + "2," + pr_object[1] + self.base_dn)
-            except LdbError, (num, _):
+            except LdbError as e8:
+                (num, _) = e8.args
                 self.fail("Could not rename " + pr_object[0])
 
             self.ldb.rename(pr_object[0] + "2," + pr_object[1] + self.base_dn,

--- a/source4/dsdb/tests/python/sec_descriptor.py
+++ b/source4/dsdb/tests/python/sec_descriptor.py
@@ -71,7 +71,8 @@ class DescriptorTests(samba.tests.TestCase):
             class_dn = "CN=%s,%s" % (class_name, self.schema_dn)
             try:
                 self.ldb_admin.search(base=class_dn, attrs=["name"])
-            except LdbError, (num, _):
+            except LdbError as e:
+                (num, _) = e.args
                 self.assertEquals(num, ERR_NO_SUCH_OBJECT)
                 break
 

--- a/source4/dsdb/tests/python/tombstone_reanimation.py
+++ b/source4/dsdb/tests/python/tombstone_reanimation.py
@@ -205,7 +205,8 @@ class BaseRestoreObjectTestCase(RestoredObjectAttributesBaseTestCase):
             FLAG_MOD_ADD, "enableOptionalFeature")
         try:
             self.samdb.modify(msg)
-        except LdbError, (num, _):
+        except LdbError as e:
+            (num, _) = e.args
             self.assertEquals(num, ERR_ATTRIBUTE_OR_VALUE_EXISTS)
 
     def test_undelete(self):
@@ -242,13 +243,15 @@ class BaseRestoreObjectTestCase(RestoredObjectAttributesBaseTestCase):
         try:
             self.samdb.rename(str(objDeleted1.dn), usr1)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e1:
+            (num, _) = e1.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
         try:
             self.samdb.rename(str(objDeleted1.dn), usr1, ["show_deleted:1"])
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e2:
+            (num, _) = e2.args
             self.assertEquals(num, ERR_UNWILLING_TO_PERFORM)
 
     def test_undelete_with_mod(self):
@@ -307,7 +310,8 @@ class BaseRestoreObjectTestCase(RestoredObjectAttributesBaseTestCase):
         try:
             self.restore_deleted_object(self.samdb, objDeleted1.dn, usr1)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e3:
+            (num, _) = e3.args
             self.assertEquals(num, ERR_ENTRY_ALREADY_EXISTS)
 
     def test_undelete_cross_nc(self):
@@ -338,13 +342,15 @@ class BaseRestoreObjectTestCase(RestoredObjectAttributesBaseTestCase):
         try:
             self.restore_deleted_object(self.samdb, objDeleted1.dn, c3)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e4:
+            (num, _) = e4.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         #try to undelete from config to base dn
         try:
             self.restore_deleted_object(self.samdb, objDeleted2.dn, c4)
             self.fail()
-        except LdbError, (num, _):
+        except LdbError as e5:
+            (num, _) = e5.args
             self.assertEquals(num, ERR_OPERATIONS_ERROR)
         #assert undeletion will work in same nc
         self.restore_deleted_object(self.samdb, objDeleted1.dn, c4)

--- a/source4/dsdb/tests/python/urgent_replication.py
+++ b/source4/dsdb/tests/python/urgent_replication.py
@@ -38,7 +38,8 @@ class UrgentReplicationTests(samba.tests.TestCase):
     def delete_force(self, ldb, dn):
         try:
             ldb.delete(dn, ["relax:0"])
-        except LdbError, (num, _):
+        except LdbError as e:
+            (num, _) = e.args
             self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
     def setUp(self):

--- a/source4/dsdb/tests/python/user_account_control.py
+++ b/source4/dsdb/tests/python/user_account_control.py
@@ -227,7 +227,8 @@ class UserAccountControlTests(samba.tests.TestCase):
         try:
             self.samdb.modify(m)
             self.fail("Unexpectedly able to set userAccountControl to be a DC on %s" % m.dn)
-        except LdbError, (enum, estr):
+        except LdbError as e5:
+            (enum, estr) = e5.args
             self.assertEqual(ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS, enum)
 
         m = ldb.Message()
@@ -237,7 +238,8 @@ class UserAccountControlTests(samba.tests.TestCase):
         try:
             self.samdb.modify(m)
             self.fail("Unexpectedly able to set userAccountControl to be an RODC on %s" % m.dn)
-        except LdbError, (enum, estr):
+        except LdbError as e6:
+            (enum, estr) = e6.args
             self.assertEqual(ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS, enum)
 
         m = ldb.Message()
@@ -247,7 +249,8 @@ class UserAccountControlTests(samba.tests.TestCase):
         try:
             self.samdb.modify(m)
             self.fail("Unexpectedly able to set userAccountControl to be an Workstation on %s" % m.dn)
-        except LdbError, (enum, estr):
+        except LdbError as e7:
+            (enum, estr) = e7.args
             self.assertEqual(ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS, enum)
 
         m = ldb.Message()
@@ -262,7 +265,8 @@ class UserAccountControlTests(samba.tests.TestCase):
                                                  ldb.FLAG_MOD_REPLACE, "primaryGroupID")
         try:
             self.samdb.modify(m)
-        except LdbError, (enum, estr):
+        except LdbError as e8:
+            (enum, estr) = e8.args
             self.assertEqual(ldb.ERR_UNWILLING_TO_PERFORM, enum)
             return
         self.fail()
@@ -297,7 +301,8 @@ class UserAccountControlTests(samba.tests.TestCase):
         try:
             self.samdb.modify(m)
             self.fail("Unexpectedly able to set userAccountControl on %s" % m.dn)
-        except LdbError, (enum, estr):
+        except LdbError as e9:
+            (enum, estr) = e9.args
             self.assertEqual(ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS, enum)
 
         m = ldb.Message()
@@ -307,7 +312,8 @@ class UserAccountControlTests(samba.tests.TestCase):
         try:
              self.samdb.modify(m)
              self.fail()
-        except LdbError, (enum, estr):
+        except LdbError as e10:
+             (enum, estr) = e10.args
              self.assertEqual(ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS, enum)
 
         m = ldb.Message()
@@ -323,7 +329,8 @@ class UserAccountControlTests(samba.tests.TestCase):
         try:
             self.samdb.modify(m)
             self.fail("Unexpectedly able to set userAccountControl to be an Workstation on %s" % m.dn)
-        except LdbError, (enum, estr):
+        except LdbError as e11:
+            (enum, estr) = e11.args
             self.assertEqual(ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS, enum)
 
 
@@ -345,7 +352,8 @@ class UserAccountControlTests(samba.tests.TestCase):
         try:
             self.admin_samdb.modify(m)
             self.fail("Unexpectedly able to set userAccountControl to UF_WORKSTATION_TRUST_ACCOUNT|UF_PARTIAL_SECRETS_ACCOUNT|UF_TRUSTED_FOR_DELEGATION on %s" % m.dn)
-        except LdbError, (enum, estr):
+        except LdbError as e12:
+            (enum, estr) = e12.args
             self.assertEqual(ldb.ERR_OTHER, enum)
 
         m = ldb.Message()
@@ -417,7 +425,8 @@ class UserAccountControlTests(samba.tests.TestCase):
                 self.samdb.modify(m)
                 if (bit in priv_bits):
                     self.fail("Unexpectedly able to set userAccountControl bit 0x%08X on %s" % (bit, m.dn))
-            except LdbError, (enum, estr):
+            except LdbError as e:
+                (enum, estr) = e.args
                 if bit in invalid_bits:
                     self.assertEqual(enum, ldb.ERR_OTHER, "was not able to set 0x%08X on %s" % (bit, m.dn))
                     # No point going on, try the next bit
@@ -492,7 +501,8 @@ class UserAccountControlTests(samba.tests.TestCase):
                 if bit in invalid_bits:
                     self.fail("Should have been unable to set userAccountControl bit 0x%08X on %s" % (bit, m.dn))
 
-            except LdbError, (enum, estr):
+            except LdbError as e1:
+                (enum, estr) = e1.args
                 if bit in invalid_bits:
                     self.assertEqual(enum, ldb.ERR_OTHER)
                     # No point going on, try the next bit
@@ -524,7 +534,8 @@ class UserAccountControlTests(samba.tests.TestCase):
                                                              ldb.FLAG_MOD_REPLACE, "userAccountControl")
                 self.samdb.modify(m)
 
-            except LdbError, (enum, estr):
+            except LdbError as e2:
+                (enum, estr) = e2.args
                 self.fail("Unable to set userAccountControl bit 0x%08X on %s: %s" % (bit, m.dn, estr))
 
             res = self.admin_samdb.search("%s" % self.base_dn,
@@ -561,7 +572,8 @@ class UserAccountControlTests(samba.tests.TestCase):
                 if bit in priv_to_remove_bits:
                     self.fail("Should have been unable to remove userAccountControl bit 0x%08X on %s" % (bit, m.dn))
 
-            except LdbError, (enum, estr):
+            except LdbError as e3:
+                (enum, estr) = e3.args
                 if bit in priv_to_remove_bits:
                     self.assertEqual(enum, ldb.ERR_INSUFFICIENT_ACCESS_RIGHTS)
                 else:
@@ -618,7 +630,8 @@ class UserAccountControlTests(samba.tests.TestCase):
                 if bit in priv_bits:
                     self.fail("Unexpectdly able to set userAccountControl bit 0x%08X on %s" % (bit, computername))
 
-            except LdbError, (enum, estr):
+            except LdbError as e4:
+                (enum, estr) = e4.args
                 if bit in invalid_bits:
                     self.assertEqual(enum, ldb.ERR_OTHER, "Invalid bit 0x%08X was able to be set on %s" % (bit, computername))
                     # No point going on, try the next bit
@@ -642,7 +655,8 @@ class UserAccountControlTests(samba.tests.TestCase):
             # When creating a new object, you can not ever set the primaryGroupID
             self.add_computer_ldap(computername, others={"primaryGroupID": [str(security.DOMAIN_RID_ADMINS)]})
             self.fail("Unexpectedly able to set primaryGruopID to be an admin on %s" % computername)
-        except LdbError, (enum, estr):
+        except LdbError as e13:
+            (enum, estr) = e13.args
             self.assertEqual(enum, ldb.ERR_UNWILLING_TO_PERFORM)
 
 
@@ -676,7 +690,8 @@ class UserAccountControlTests(samba.tests.TestCase):
 
             # When creating a new object, you can not ever set the primaryGroupID
             self.fail("Unexpectedly able to set primaryGroupID to be other than DCS on %s" % computername)
-        except LdbError, (enum, estr):
+        except LdbError as e14:
+            (enum, estr) = e14.args
             self.assertEqual(enum, ldb.ERR_UNWILLING_TO_PERFORM)
 
     def test_primarygroupID_priv_member_modify(self):
@@ -709,7 +724,8 @@ class UserAccountControlTests(samba.tests.TestCase):
 
             # When creating a new object, you can not ever set the primaryGroupID
             self.fail("Unexpectedly able to set primaryGroupID to be other than DCS on %s" % computername)
-        except LdbError, (enum, estr):
+        except LdbError as e15:
+            (enum, estr) = e15.args
             self.assertEqual(enum, ldb.ERR_UNWILLING_TO_PERFORM)
 
 

--- a/source4/torture/drs/python/getnc_exop.py
+++ b/source4/torture/drs/python/getnc_exop.py
@@ -89,7 +89,8 @@ class DrsReplicaSyncTestCase(drs_base.DrsBaseTestCase):
     def tearDown(self):
         try:
             self.ldb_dc1.delete(self.ou, ["tree_delete:1"])
-        except ldb.LdbError as (enum, string):
+        except ldb.LdbError as e:
+            (enum, string) = e.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
         super(DrsReplicaSyncTestCase, self).tearDown()
@@ -233,7 +234,8 @@ class DrsReplicaSyncTestCase(drs_base.DrsBaseTestCase):
         try:
             (level, ctr) = self.drs.DsGetNCChanges(self.drs_handle, 8, req8)
             self.fail("Expected DsGetNCChanges to fail with WERR_DS_CANT_FIND_EXPECTED_NC")
-        except WERRORError as (enum, estr):
+        except WERRORError as e1:
+            (enum, estr) = e1.args
             self.assertEquals(enum, werror.WERR_DS_CANT_FIND_EXPECTED_NC)
 
     def test_link_utdv_hwm(self):
@@ -610,7 +612,8 @@ class DrsReplicaPrefixMapTestCase(drs_base.DrsBaseTestCase):
         super(DrsReplicaPrefixMapTestCase, self).tearDown()
         try:
             self.ldb_dc1.delete(self.ou, ["tree_delete:1"])
-        except ldb.LdbError as (enum, string):
+        except ldb.LdbError as e2:
+            (enum, string) = e2.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
 
@@ -661,7 +664,8 @@ class DrsReplicaPrefixMapTestCase(drs_base.DrsBaseTestCase):
         try:
             (level, ctr) = drs.DsGetNCChanges(drs_handle, 8, req8)
             self.fail("Invalid attid (99999) should have triggered an error")
-        except RuntimeError as (ecode, emsg):
+        except RuntimeError as e3:
+            (ecode, emsg) = e3.args
             self.assertEqual(ecode, 0x000020E2, "Error code should have been "
                              "WERR_DS_DRA_SCHEMA_MISMATCH")
 
@@ -950,7 +954,8 @@ class DrsReplicaSyncSortTestCase(drs_base.DrsBaseTestCase):
         # tidyup groups and users
         try:
             self.ldb_dc1.delete(self.ou, ["tree_delete:1"])
-        except ldb.LdbError as (enum, string):
+        except ldb.LdbError as e4:
+            (enum, string) = e4.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
 

--- a/source4/torture/drs/python/getnc_unpriv.py
+++ b/source4/torture/drs/python/getnc_unpriv.py
@@ -89,7 +89,8 @@ class DrsReplicaSyncUnprivTestCase(drs_base.DrsBaseTestCase):
         self.sd_utils.modify_sd_on_dn(self.base_dn, self.desc_sddl)
         try:
             self.ldb_dc1.delete(self.ou, ["tree_delete:1"])
-        except ldb.LdbError as (enum, string):
+        except ldb.LdbError as e1:
+            (enum, string) = e1.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
         super(DrsReplicaSyncUnprivTestCase, self).tearDown()
@@ -117,7 +118,8 @@ class DrsReplicaSyncUnprivTestCase(drs_base.DrsBaseTestCase):
                 (level, ctr) = self.user_drs.DsGetNCChanges(self.user_drs_handle,
                                                             8, req8)
                 self.fail("Should have failed with user denied access")
-            except WERRORError as (enum, estr):
+            except WERRORError as e:
+                (enum, estr) = e.args
                 self.assertTrue(enum in expected_error,
                                 "Got unexpected error: %s" % estr)
 

--- a/source4/torture/drs/python/getncchanges.py
+++ b/source4/torture/drs/python/getncchanges.py
@@ -63,7 +63,8 @@ class DrsReplicaSyncIntegrityTestCase(drs_base.DrsBaseTestCase):
         # tidyup groups and users
         try:
             self.ldb_dc2.delete(self.ou, ["tree_delete:1"])
-        except ldb.LdbError as (enum, string):
+        except ldb.LdbError as e:
+            (enum, string) = e.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
 

--- a/source4/torture/drs/python/repl_move.py
+++ b/source4/torture/drs/python/repl_move.py
@@ -89,7 +89,8 @@ class DrsMoveObjectTestCase(drs_base.DrsBaseTestCase):
     def tearDown(self):
         try:
             self.ldb_dc1.delete(self.ou1_dn, ["tree_delete:1"])
-        except ldb.LdbError as (enum, string):
+        except ldb.LdbError as e:
+            (enum, string) = e.args
             if enum == ldb.ERR_NO_SUCH_OBJECT:
                 pass
 

--- a/source4/torture/drs/python/repl_rodc.py
+++ b/source4/torture/drs/python/repl_rodc.py
@@ -199,14 +199,16 @@ class DrsRodcTestCase(drs_base.DrsBaseTestCase):
         try:
             (level, ctr) = self.rodc_drs.DsGetNCChanges(self.rodc_drs_handle, 10, req10)
             self.fail("Successfully replicated secrets to an RODC that shouldn't have been replicated.")
-        except WERRORError as (enum, estr):
+        except WERRORError as e:
+            (enum, estr) = e.args
             self.assertEquals(enum, 8630) # ERROR_DS_DRA_SECRETS_DENIED
 
         # send the same request again and we should get the same response
         try:
             (level, ctr) = self.rodc_drs.DsGetNCChanges(self.rodc_drs_handle, 10, req10)
             self.fail("Successfully replicated secrets to an RODC that shouldn't have been replicated.")
-        except WERRORError as (enum, estr):
+        except WERRORError as e1:
+            (enum, estr) = e1.args
             self.assertEquals(enum, 8630) # ERROR_DS_DRA_SECRETS_DENIED
 
         # Retry with Administrator credentials, ignores password replication groups
@@ -245,7 +247,8 @@ class DrsRodcTestCase(drs_base.DrsBaseTestCase):
             (level, ctr) = self.rodc_drs.DsGetNCChanges(self.rodc_drs_handle, 8, req8)
 
             self.fail("Successfully replicated secrets to an RODC that shouldn't have been replicated.")
-        except RuntimeError as (enum, estr):
+        except RuntimeError as e2:
+            (enum, estr) = e2.args
             pass
 
     def test_msDSRevealedUsers_admin(self):
@@ -506,7 +509,8 @@ class DrsRodcTestCase(drs_base.DrsBaseTestCase):
         try:
             (level, ctr) = self.rodc_drs.DsGetNCChanges(self.rodc_drs_handle, 10, req10)
             self.fail("Successfully replicated secrets to an RODC that shouldn't have been replicated.")
-        except WERRORError as (enum, estr):
+        except WERRORError as e3:
+            (enum, estr) = e3.args
             self.assertEquals(enum, 8630) # ERROR_DS_DRA_SECRETS_DENIED
 
         req10 = self._getnc_req10(dest_dsa=str(self.rodc_ctx.ntds_guid),
@@ -520,7 +524,8 @@ class DrsRodcTestCase(drs_base.DrsBaseTestCase):
         try:
             (level, ctr) = other_rodc_drs.DsGetNCChanges(other_rodc_drs_handle, 10, req10)
             self.fail("Successfully replicated secrets to an RODC that shouldn't have been replicated.")
-        except WERRORError as (enum, estr):
+        except WERRORError as e4:
+            (enum, estr) = e4.args
             self.assertEquals(enum, 8630) # ERROR_DS_DRA_SECRETS_DENIED
 
     def test_msDSRevealedUsers_local_deny_allow(self):
@@ -589,7 +594,8 @@ class DrsRodcTestCase(drs_base.DrsBaseTestCase):
         try:
             (level, ctr) = self.rodc_drs.DsGetNCChanges(self.rodc_drs_handle, 10, req10)
             self.fail("Successfully replicated secrets to an RODC that shouldn't have been replicated.")
-        except WERRORError as (enum, estr):
+        except WERRORError as e5:
+            (enum, estr) = e5.args
             self.assertEquals(enum, 8630) # ERROR_DS_DRA_SECRETS_DENIED
 
         m = ldb.Message()
@@ -605,7 +611,8 @@ class DrsRodcTestCase(drs_base.DrsBaseTestCase):
         try:
             (level, ctr) = self.rodc_drs.DsGetNCChanges(self.rodc_drs_handle, 10, req10)
             self.fail("Successfully replicated secrets to an RODC that shouldn't have been replicated.")
-        except WERRORError as (enum, estr):
+        except WERRORError as e6:
+            (enum, estr) = e6.args
             self.assertEquals(enum, 8630) # ERROR_DS_DRA_SECRETS_DENIED
 
     def _assert_in_revealed_users(self, user_dn, attrlist):

--- a/source4/torture/drs/python/repl_schema.py
+++ b/source4/torture/drs/python/repl_schema.py
@@ -132,7 +132,8 @@ class DrsReplSchemaTestCase(drs_base.DrsBaseTestCase):
         # add it to the Schema
         try:
             ldb_ctx.add(rec)
-        except LdbError, (enum, estr):
+        except LdbError as e:
+            (enum, estr) = e.args
             self.fail("Adding record failed with %d/%s" % (enum, estr))
 
         self._ldap_schemaUpdateNow(ldb_ctx)
@@ -170,7 +171,8 @@ class DrsReplSchemaTestCase(drs_base.DrsBaseTestCase):
             res_dc2 = self.ldb_dc2.search(base=obj_dn,
                                           scope=SCOPE_BASE,
                                           attrs=["*"])
-        except LdbError, (enum, estr):
+        except LdbError as e1:
+            (enum, estr) = e1.args
             if enum == ERR_NO_SUCH_OBJECT:
                 self.fail("%s doesn't exists on %s" % (obj_dn, self.dnsname_dc2))
             raise
@@ -439,7 +441,8 @@ class DrsReplSchemaTestCase(drs_base.DrsBaseTestCase):
                                c_dn.get_component_value(0) + "-NEW")
         try:
             self.ldb_dc1.rename(c_dn, c_dn_new)
-        except LdbError, (num, _):
+        except LdbError as e2:
+            (num, _) = e2.args
             self.fail("failed to change CN for %s: %s" % (c_dn, _))
 
         # force replication from DC1 to DC2

--- a/source4/torture/drs/python/replica_sync.py
+++ b/source4/torture/drs/python/replica_sync.py
@@ -62,11 +62,13 @@ class DrsReplicaSyncTestCase(drs_base.DrsBaseTestCase):
         if guid is not None:
             try:
                 self.ldb_dc2.delete('<GUID=%s>' % guid, ["tree_delete:1"])
-            except LdbError, (num, _):
+            except LdbError as e:
+                (num, _) = e.args
                 self.assertEquals(num, ERR_NO_SUCH_OBJECT)
             try:
                 self.ldb_dc1.delete('<GUID=%s>' % guid, ["tree_delete:1"])
-            except LdbError, (num, _):
+            except LdbError as e1:
+                (num, _) = e1.args
                 self.assertEquals(num, ERR_NO_SUCH_OBJECT)
 
     def test_ReplEnabled(self):

--- a/source4/torture/drs/python/ridalloc_exop.py
+++ b/source4/torture/drs/python/ridalloc_exop.py
@@ -217,7 +217,8 @@ class DrsReplicaSyncTestCase(drs_base.DrsBaseTestCase):
         try:
             # ldb_dc1 is now RID MASTER (as VAMPIREDC)
             ldb_dc1.modify(m)
-        except ldb.LdbError, (num, msg):
+        except ldb.LdbError as e1:
+            (num, msg) = e1.args
             self.fail("Failed to reassign RID Master " +  msg)
 
         try:
@@ -257,7 +258,8 @@ class DrsReplicaSyncTestCase(drs_base.DrsBaseTestCase):
             m["becomeRidMaster"] = ldb.MessageElement("1", ldb.FLAG_MOD_REPLACE, "becomeRidMaster")
             try:
                 ldb_dc2.modify(m)
-            except ldb.LdbError, (num, msg):
+            except ldb.LdbError as e:
+                (num, msg) = e.args
                 self.fail("Failed to restore RID Master " +  msg)
 
     def test_offline_samba_tool_seized_ridalloc(self):


### PR DESCRIPTION
This is a bulk conversion of except clause specifies a tuple following the exception name. This format is illegal in python3 e.g.

convert

    except LdbError, (num, msg):
to
    except LdbError as e:
         (num, msg) = e.args

The patches follow the same grouping as a previous 'Bulk' commit for converting except clause with ',' instead of 'as'

