### PR TITLE
Python3: Bulk literal octal number conversion

### DIFF
--- a/python/samba/netcmd/user.py
+++ b/python/samba/netcmd/user.py
@@ -1807,7 +1807,7 @@ samba-tool user syncpasswords --terminate \\
                     logfile = self.logfile
                     self.logfile = None
                     log_msg("Closing logfile[%s] (st_nlink == 0)\n" % (logfile))
-                    logfd = os.open(logfile, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0600)
+                    logfd = os.open(logfile, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
                     os.dup2(logfd, 0)
                     os.dup2(logfd, 1)
                     os.dup2(logfd, 2)
@@ -1969,7 +1969,7 @@ samba-tool user syncpasswords --terminate \\
                 flags |= os.O_CREAT
 
             try:
-                self.lockfd = os.open(self.lockfile, flags, 0600)
+                self.lockfd = os.open(self.lockfile, flags, 0o600)
             except IOError as (err, msg):
                 if err == errno.ENOENT:
                     if terminate:
@@ -2212,7 +2212,7 @@ samba-tool user syncpasswords --terminate \\
             maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
             if maxfd == resource.RLIM_INFINITY:
                 maxfd = 1024 # Rough guess at maximum number of open file descriptors.
-            logfd = os.open(logfile, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0600)
+            logfd = os.open(logfile, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
             self.outf.write("Using logfile[%s]\n" % logfile)
             for fd in range(0, maxfd):
                 if fd == logfd:

--- a/python/samba/provision/__init__.py
+++ b/python/samba/provision/__init__.py
@@ -1213,7 +1213,7 @@ def getpolicypath(sysvolpath, dnsdomain, guid):
 
 def create_gpo_struct(policy_path):
     if not os.path.exists(policy_path):
-        os.makedirs(policy_path, 0775)
+        os.makedirs(policy_path, 0o775)
     f = open(os.path.join(policy_path, "GPT.INI"), 'w')
     try:
         f.write("[General]\r\nVersion=0")
@@ -1221,10 +1221,10 @@ def create_gpo_struct(policy_path):
         f.close()
     p = os.path.join(policy_path, "MACHINE")
     if not os.path.exists(p):
-        os.makedirs(p, 0775)
+        os.makedirs(p, 0o775)
     p = os.path.join(policy_path, "USER")
     if not os.path.exists(p):
-        os.makedirs(p, 0775)
+        os.makedirs(p, 0o775)
 
 
 def create_default_gpo(sysvolpath, dnsdomain, policyguid, policyguid_dc):
@@ -1613,7 +1613,7 @@ def setsysvolacl(samdb, netlogon, sysvol, uid, gid, domainsid, dnsdomain,
         file = tempfile.NamedTemporaryFile(dir=os.path.abspath(sysvol))
         try:
             try:
-                smbd.set_simple_acl(file.name, 0755, gid)
+                smbd.set_simple_acl(file.name, 0o755, gid)
             except OSError:
                 if not smbd.have_posix_acls():
                     # This clue is only strictly correct for RPM and
@@ -2160,7 +2160,7 @@ def provision(logger, session_info, smbconf=None,
         setup_encrypted_secrets_key(paths.encrypted_secrets_key_path)
 
     if paths.sysvol and not os.path.exists(paths.sysvol):
-        os.makedirs(paths.sysvol, 0775)
+        os.makedirs(paths.sysvol, 0o775)
 
     ldapi_url = "ldapi://%s" % urllib.quote(paths.s4_ldapi_path, safe="")
 
@@ -2240,7 +2240,7 @@ def provision(logger, session_info, smbconf=None,
                 raise MissingShareError("sysvol", paths.smbconf)
 
             if not os.path.isdir(paths.netlogon):
-                os.makedirs(paths.netlogon, 0755)
+                os.makedirs(paths.netlogon, 0o755)
 
         if adminpass is None:
             adminpass = samba.generate_random_password(12, 32)
@@ -2312,7 +2312,7 @@ def provision(logger, session_info, smbconf=None,
         # chown the dns.keytab in the bind-dns directory
         if paths.bind_gid is not None:
             try:
-                os.chmod(paths.binddns_dir, 0770)
+                os.chmod(paths.binddns_dir, 0o770)
                 os.chown(paths.binddns_dir, -1, paths.bind_gid)
             except OSError:
                 if not os.environ.has_key('SAMBA_SELFTEST'):
@@ -2320,7 +2320,7 @@ def provision(logger, session_info, smbconf=None,
                                 paths.binddns_dir, paths.bind_gid)
 
             try:
-                os.chmod(bind_dns_keytab_path, 0640)
+                os.chmod(bind_dns_keytab_path, 0o640)
                 os.chown(bind_dns_keytab_path, -1, paths.bind_gid)
             except OSError:
                 if not os.environ.has_key('SAMBA_SELFTEST'):

--- a/python/samba/provision/backend.py
+++ b/python/samba/provision/backend.py
@@ -223,7 +223,7 @@ class LDAPBackend(ProvisionBackend):
                 self.slapd_path)
 
         if not os.path.isdir(self.ldapdir):
-            os.makedirs(self.ldapdir, 0700)
+            os.makedirs(self.ldapdir, 0o700)
 
         # Put the LDIF of the schema into a database so we can search on
         # it to generate schema-dependent configurations in Fedora DS and
@@ -259,7 +259,7 @@ class LDAPBackend(ProvisionBackend):
         finally:
             f.close()
 
-        os.chmod(ldap_backend_script, 0755)
+        os.chmod(ldap_backend_script, 0o755)
 
         # Now start the slapd, so we can provision onto it.  We keep the
         # subprocess context around, to kill this off at the successful
@@ -346,7 +346,7 @@ class OpenLDAPBackend(LDAPBackend):
         :param dbdir: Database directory.
         """
         if not os.path.exists(dbdir):
-            os.makedirs(dbdir, 0700)
+            os.makedirs(dbdir, 0o700)
 
     def provision(self):
         from samba.provision import ProvisioningError, setup_path
@@ -578,7 +578,7 @@ class OpenLDAPBackend(LDAPBackend):
 
         # Wipe the old sam.ldb databases away
         shutil.rmtree(self.olcdir, True)
-        os.makedirs(self.olcdir, 0770)
+        os.makedirs(self.olcdir, 0o770)
 
         # If we were just looking for crashes up to this point, it's a
         # good time to exit before we realise we don't have OpenLDAP on

--- a/python/samba/provision/sambadns.py
+++ b/python/samba/provision/sambadns.py
@@ -694,13 +694,13 @@ def create_dns_dir(logger, paths):
     except OSError:
         pass
 
-    os.mkdir(dns_dir, 0770)
+    os.mkdir(dns_dir, 0o770)
 
     if paths.bind_gid is not None:
         try:
             os.chown(dns_dir, -1, paths.bind_gid)
             # chmod needed to cope with umask
-            os.chmod(dns_dir, 0770)
+            os.chmod(dns_dir, 0o770)
         except OSError:
             if not os.environ.has_key('SAMBA_SELFTEST'):
                 logger.error("Failed to chown %s to bind gid %u" % (
@@ -767,7 +767,7 @@ def create_zone_file(lp, logger, paths, targetdir, dnsdomain,
         try:
             os.chown(paths.dns, -1, paths.bind_gid)
             # chmod needed to cope with umask
-            os.chmod(paths.dns, 0664)
+            os.chmod(paths.dns, 0o664)
         except OSError:
             if not os.environ.has_key('SAMBA_SELFTEST'):
                 logger.error("Failed to chown %s to bind gid %u" % (
@@ -873,12 +873,12 @@ def create_samdb_copy(samdb, logger, paths, names, domainsid, domainguid):
                 for d in dirs:
                     dpath = os.path.join(dirname, d)
                     os.chown(dpath, -1, paths.bind_gid)
-                    os.chmod(dpath, 0770)
+                    os.chmod(dpath, 0o770)
                 for f in files:
                     if f.endswith('.ldb') or f.endswith('.tdb'):
                         fpath = os.path.join(dirname, f)
                         os.chown(fpath, -1, paths.bind_gid)
-                        os.chmod(fpath, 0660)
+                        os.chmod(fpath, 0o660)
         except OSError:
             if not os.environ.has_key('SAMBA_SELFTEST'):
                 logger.error(

--- a/python/samba/tests/posixacl.py
+++ b/python/samba/tests/posixacl.py
@@ -66,7 +66,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         setntacl(self.lp, self.tempf, acl, "S-1-5-21-2212615479-2695158682-2101375467", use_ntvfs=True)
 
         # This will invalidate the ACL, as we have a hook!
-        smbd.set_simple_acl(self.tempf, 0640)
+        smbd.set_simple_acl(self.tempf, 0o640)
 
         # However, this only asks the xattr
         try:
@@ -106,7 +106,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
     def test_setntacl_smbd_invalidate_getntacl_smbd(self):
         acl = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
         simple_acl_from_posix = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)(A;;0x001200a9;;;S-1-5-21-2212615479-2695158682-2101375467-513)(A;;;;;WD)"
-        os.chmod(self.tempf, 0750)
+        os.chmod(self.tempf, 0o750)
         setntacl(self.lp, self.tempf, acl, "S-1-5-21-2212615479-2695158682-2101375467", use_ntvfs=False)
 
         # This should invalidate the ACL, as we include the posix ACL in the hash
@@ -138,7 +138,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         simple_acl_from_posix = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;;0x001f019f;;;S-1-5-21-2212615479-2695158682-2101375467-512)(A;;0x00120089;;;S-1-5-21-2212615479-2695158682-2101375467-513)(A;;;;;WD)"
         setntacl(self.lp, self.tempf, acl, "S-1-5-21-2212615479-2695158682-2101375467", use_ntvfs=False)
         # This invalidates the hash of the NT acl just set because there is a hook in the posix ACL set code
-        smbd.set_simple_acl(self.tempf, 0640)
+        smbd.set_simple_acl(self.tempf, 0o640)
         facl = getntacl(self.lp, self.tempf, direct_db_access=False)
         anysid = security.dom_sid(security.SID_NT_SELF)
         self.assertEquals(simple_acl_from_posix, facl.as_sddl(anysid))
@@ -151,7 +151,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         # This invalidates the hash of the NT acl just set because there is a hook in the posix ACL set code
         s4_passdb = passdb.PDB(self.lp.get("passdb backend"))
         (BA_gid,BA_type) = s4_passdb.sid_to_id(BA_sid)
-        smbd.set_simple_acl(self.tempf, 0640, BA_gid)
+        smbd.set_simple_acl(self.tempf, 0o640, BA_gid)
 
         # This should re-calculate an ACL based on the posix details
         facl = getntacl(self.lp,self.tempf, direct_db_access=False)
@@ -174,7 +174,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         posix_acl = smbd.get_sys_acl(self.tempf, smb_acl.SMB_ACL_TYPE_ACCESS)
 
     def test_setposixacl_getposixacl(self):
-        smbd.set_simple_acl(self.tempf, 0640)
+        smbd.set_simple_acl(self.tempf, 0o640)
         posix_acl = smbd.get_sys_acl(self.tempf, smb_acl.SMB_ACL_TYPE_ACCESS)
         self.assertEquals(posix_acl.count, 4, self.print_posix_acl(posix_acl))
 
@@ -192,7 +192,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
 
     def test_setposixacl_getntacl(self):
         acl = ""
-        smbd.set_simple_acl(self.tempf, 0750)
+        smbd.set_simple_acl(self.tempf, 0o750)
         try:
             facl = getntacl(self.lp, self.tempf)
             self.assertTrue(False)
@@ -204,7 +204,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         s4_passdb = passdb.PDB(self.lp.get("passdb backend"))
         group_SID = s4_passdb.gid_to_sid(os.stat(self.tempf).st_gid)
         user_SID = s4_passdb.uid_to_sid(os.stat(self.tempf).st_uid)
-        smbd.set_simple_acl(self.tempf, 0640)
+        smbd.set_simple_acl(self.tempf, 0o640)
         facl = getntacl(self.lp, self.tempf, direct_db_access=False)
         acl = "O:%sG:%sD:(A;;0x001f019f;;;%s)(A;;0x00120089;;;%s)(A;;;;;WD)" % (user_SID, group_SID, user_SID, group_SID)
         anysid = security.dom_sid(security.SID_NT_SELF)
@@ -221,7 +221,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         (SO_id,SO_type) = s4_passdb.sid_to_id(SO_sid)
         self.assertEquals(SO_type, idmap.ID_TYPE_BOTH)
         smbd.chown(self.tempdir, BA_id, SO_id)
-        smbd.set_simple_acl(self.tempdir, 0750)
+        smbd.set_simple_acl(self.tempdir, 0o750)
         facl = getntacl(self.lp, self.tempdir, direct_db_access=False)
         acl = "O:BAG:SOD:(A;;0x001f01ff;;;BA)(A;;0x001200a9;;;SO)(A;;;;;WD)(A;OICIIO;0x001f01ff;;;CO)(A;OICIIO;0x001200a9;;;CG)(A;OICIIO;0x001200a9;;;WD)"
 
@@ -235,7 +235,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         group_SID = s4_passdb.gid_to_sid(os.stat(self.tempf).st_gid)
         user_SID = s4_passdb.uid_to_sid(os.stat(self.tempf).st_uid)
         self.assertEquals(BA_type, idmap.ID_TYPE_BOTH)
-        smbd.set_simple_acl(self.tempf, 0640, BA_gid)
+        smbd.set_simple_acl(self.tempf, 0o640, BA_gid)
         facl = getntacl(self.lp, self.tempf, direct_db_access=False)
         domsid = passdb.get_global_sam_sid()
         acl = "O:%sG:%sD:(A;;0x001f019f;;;%s)(A;;0x00120089;;;BA)(A;;0x00120089;;;%s)(A;;;;;WD)" % (user_SID, group_SID, user_SID, group_SID)
@@ -243,7 +243,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         self.assertEquals(acl, facl.as_sddl(anysid))
 
     def test_setposixacl_getposixacl(self):
-        smbd.set_simple_acl(self.tempf, 0640)
+        smbd.set_simple_acl(self.tempf, 0o640)
         posix_acl = smbd.get_sys_acl(self.tempf, smb_acl.SMB_ACL_TYPE_ACCESS)
         self.assertEquals(posix_acl.count, 4, self.print_posix_acl(posix_acl))
 
@@ -260,7 +260,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         self.assertEquals(posix_acl.acl[3].a_perm, 7)
 
     def test_setposixacl_dir_getposixacl(self):
-        smbd.set_simple_acl(self.tempdir, 0750)
+        smbd.set_simple_acl(self.tempdir, 0o750)
         posix_acl = smbd.get_sys_acl(self.tempdir, smb_acl.SMB_ACL_TYPE_ACCESS)
         self.assertEquals(posix_acl.count, 4, self.print_posix_acl(posix_acl))
 
@@ -281,7 +281,7 @@ class PosixAclMappingTests(TestCaseInTempDir):
         s4_passdb = passdb.PDB(self.lp.get("passdb backend"))
         (BA_gid,BA_type) = s4_passdb.sid_to_id(BA_sid)
         self.assertEquals(BA_type, idmap.ID_TYPE_BOTH)
-        smbd.set_simple_acl(self.tempf, 0670, BA_gid)
+        smbd.set_simple_acl(self.tempf, 0o670, BA_gid)
         posix_acl = smbd.get_sys_acl(self.tempf, smb_acl.SMB_ACL_TYPE_ACCESS)
 
         self.assertEquals(posix_acl.count, 5, self.print_posix_acl(posix_acl))

--- a/python/samba/tests/source.py
+++ b/python/samba/tests/source.py
@@ -199,7 +199,7 @@ class TestSource(TestCase):
         for fname, line_no, line in self._iter_source_files_lines():
             if line_no >= 1:
                 continue
-            executable = (os.stat(fname).st_mode & 0111)
+            executable = (os.stat(fname).st_mode & 0o111)
             has_shebang = line.startswith("#!")
             if has_shebang and not executable:
                 self._push_file(files_with_shebang, fname, line_no)


### PR DESCRIPTION
This patch converts literal octal numbers to a format that is acceptable in both python2 and python3.
e.g.

convert
           os.chmod(some_path, 0770)      # valid in python2 only
           os.chmod(some_path, 0o770)    # valid in python2 and python3

The commits follow the same pattern of patch grouping as a previous bulk conversion patch