### PR TITLE
samba-tool domain trust: fix trust compatibility to Windows Server 1709 and FreeIPA

### DIFF
--- a/python/samba/netcmd/domain.py
+++ b/python/samba/netcmd/domain.py
@@ -2488,7 +2488,11 @@ class cmd_domain_trust_create(DomainTrustCommand):
             try:
                 remote_netlogon_info = self.get_netlogon_dc_info(remote_netlogon, remote_server)
             except RuntimeError as error:
-                raise self.RemoteRuntimeError(self, error, "failed to get netlogon dc info")
+                # Direct connection failed, re-try via our DC
+                try:
+                    remote_netlogon_info = self.get_netlogon_dc_info(local_netlogon, remote_server)
+                except RuntimeError as error:
+                    raise self.RemoteRuntimeError(self, error, "failed to get netlogon dc info")
 
         def generate_AuthInOutBlob(secret, update_time):
             if secret is None:


### PR DESCRIPTION
Two patches from this pull request attempt to fix compatibilities to Windows Server 1709 and FreeIPA.

FreeIPA does not implement netr_DsRGetDCNameEx2() in a way that can be used by `samba-tool`, so a DC search fails when running `samba-tool domain trust create`. Insteda, use netr_DsRGetDCNameEx2() with a remote server name to call own DC. This should cause our own DC to use CLDAP discovery which is supported by FreeIPA.

Windows Server 1709 disabled SMB1 by default, so one has to set `client ipc min protocol = SMB2` to get trust established. While this is a proper fix going forward, it makes sense to default to SMB2 internally when establishing LSA and Netlogon RPC connections even if `smb.conf` lacks the correct option and fall back to an older protocol only if smb2 fails. This is an approach already used by FreeIPA DC for few years.

Submitting via github to get a test build run.