### PR TITLE
Parallel test for master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
+image: registry.gitlab.com/catalyst-samba/samba:latest
+
 before_script:
   - echo "Build starting (preparing swap)..."
   - sudo dd if=/dev/zero of=/samba-swap bs=1M count=10240 
@@ -9,7 +11,7 @@ before_script:
 build_samba:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     # this one takes about 4 hours to finish
     - python script/autobuild.py samba            --verbose --tail --testbase /tmp/samba-testbase
@@ -17,7 +19,7 @@ build_samba:
 build_samba_others:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     - python script/autobuild.py samba-nopython   --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py samba-systemkrb5 --verbose --tail --testbase /tmp/samba-testbase
@@ -29,7 +31,7 @@ build_samba_others:
 build_ctdb:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     - python script/autobuild.py samba-ctdb       --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py ctdb             --verbose --tail --testbase /tmp/samba-testbase
@@ -37,7 +39,7 @@ build_ctdb:
 build_others:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     - python script/autobuild.py ldb              --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py pidl             --verbose --tail --testbase /tmp/samba-testbase

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,10 @@
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
 before_script:
-  - echo "Build starting ..."
+  - echo "Build starting (preparing swap)..."
+  - sudo dd if=/dev/zero of=/samba-swap bs=1M count=10240 
+  - sudo mkswap /samba-swap
+  - sudo swapon /samba-swap
 
 build_samba:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,10 @@
 
 image: registry.gitlab.com/catalyst-samba/samba:latest
 
+variables:
+  GIT_STRATEGY: fetch
+  GIT_DEPTH: "3"
+
 before_script:
   - echo "Build starting (preparing swap)..."
   - sudo dd if=/dev/zero of=/samba-swap bs=1M count=10240 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ build_samba:
   stage: build
   tags:
     - docker
+    - private
   script:
     # this one takes about 4 hours to finish
     - python script/autobuild.py samba            --verbose --tail --testbase /tmp/samba-testbase
@@ -23,7 +24,8 @@ build_samba:
 build_samba_nt4:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - private
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
@@ -31,7 +33,8 @@ build_samba_nt4:
 build_samba_fileserver:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - shared
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-fileserver --verbose --tail --testbase /tmp/samba-testbase
@@ -39,7 +42,8 @@ build_samba_fileserver:
 build_samba_ad_dc:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - private
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-ad-dc     --verbose --tail --testbase /tmp/samba-testbase
@@ -47,7 +51,8 @@ build_samba_ad_dc:
 build_samba_none_env:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - shared
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-none-env    --verbose --tail --testbase /tmp/samba-testbase
@@ -56,6 +61,7 @@ build_samba_others:
   stage: build
   tags:
     - docker
+    - shared
   script:
     - python script/autobuild.py samba-nopython   --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py samba-systemkrb5 --verbose --tail --testbase /tmp/samba-testbase
@@ -68,6 +74,7 @@ build_ctdb:
   stage: build
   tags:
     - docker
+    - shared
   script:
     - python script/autobuild.py samba-ctdb       --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py ctdb             --verbose --tail --testbase /tmp/samba-testbase
@@ -76,6 +83,7 @@ build_others:
   stage: build
   tags:
     - docker
+    - shared
   script:
     - python script/autobuild.py ldb              --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py pidl             --verbose --tail --testbase /tmp/samba-testbase

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,14 @@ build_samba_nt4:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_fileserver:
+  stage: build
+  tags:
+    - autobuild
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-fileserver --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_ad_dc:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,14 @@ build_samba:
     # this one takes about 4 hours to finish
     - python script/autobuild.py samba            --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_nt4:
+  stage: build
+  tags:
+    - autobuild
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_others:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,14 @@ build_samba_nt4:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_none_env:
+  stage: build
+  tags:
+    - autobuild
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-none-env    --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_others:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,14 @@ build_samba_nt4:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_ad_dc:
+  stage: build
+  tags:
+    - autobuild
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-ad-dc     --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_none_env:
   stage: build
   tags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - TASK=samba-o3
   - TASK=samba-nopython
   - TASK=samba-systemkrb5
+  - TASK=samba-nt4
   - TASK=ldb
   - TASK=tdb
   - TASK=talloc

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - TASK=samba-libs
   - TASK=samba-static
   - TASK=samba-o3
+  - TASK=samba-none-env
   - TASK=samba-nopython
   - TASK=samba-systemkrb5
   - TASK=samba-nt4

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - TASK=samba-nopython
   - TASK=samba-systemkrb5
   - TASK=samba-nt4
+  - TASK=samba-fileserver
   - TASK=samba-ad-dc
   - TASK=ldb
   - TASK=tdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - TASK=samba-nopython
   - TASK=samba-systemkrb5
   - TASK=samba-nt4
+  - TASK=samba-ad-dc
   - TASK=ldb
   - TASK=tdb
   - TASK=talloc

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install --assume-yes acl attr autoconf bind9utils bison build-essential debhelper dnsutils docbook-xml docbook-xsl flex gdb libjansson-dev krb5-user libacl1-dev libaio-dev libarchive-dev libattr1-dev libblkid-dev libbsd-dev libcap-dev libcups2-dev libgnutls-dev libgpgme11-dev libjson-perl libldap2-dev libncurses5-dev libpam0g-dev libparse-yapp-perl libpopt-dev libreadline-dev nettle-dev perl perl-modules pkg-config python-all-dev python-crypto python-dbg python-dev python-dnspython python3-dnspython python-gpgme python3-gpgme python-markdown python3-markdown python3-dev xsltproc zlib1g-dev
+ - sudo apt-get install --assume-yes binutils-gold 
+ - sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20
+ - sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10
+ - sudo update-alternatives --set ld /usr/bin/ld.gold
 
 script:
  - if [ $TASK = "pidl" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,7 @@ before_install:
  - sudo apt-get install --assume-yes acl attr autoconf bind9utils bison build-essential debhelper dnsutils docbook-xml docbook-xsl flex gdb libjansson-dev krb5-user libacl1-dev libaio-dev libarchive-dev libattr1-dev libblkid-dev libbsd-dev libcap-dev libcups2-dev libgnutls-dev libgpgme11-dev libjson-perl libldap2-dev libncurses5-dev libpam0g-dev libparse-yapp-perl libpopt-dev libreadline-dev nettle-dev perl perl-modules pkg-config python-all-dev python-crypto python-dbg python-dev python-dnspython python3-dnspython python-gpgme python3-gpgme python-markdown python3-markdown python3-dev xsltproc zlib1g-dev
 
 script:
- - git fetch --unshallow
+ - if [ $TASK = "pidl" ]; then
+    git fetch --unshallow;
+   fi	
  - ./script/autobuild.py --tail --testbase=/tmp $TASK

--- a/lib/torture/subunit.c
+++ b/lib/torture/subunit.c
@@ -62,9 +62,9 @@ static void torture_subunit_report_time(struct torture_context *tctx)
 		return;
 	}
 
-	tmp = localtime(&tp.tv_sec);
+	tmp = gmtime(&tp.tv_sec);
 	if (!tmp) {
-		perror("localtime");
+		perror("gmtime");
 		return;
 	}
 

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -44,7 +44,21 @@ builddirs = {
     "retry"   : "."
     }
 
-defaulttasks = [ "ctdb", "samba", "samba-xc", "samba-o3", "samba-ctdb", "samba-libs", "samba-static", "samba-systemkrb5", "samba-nopython", "ldb", "tdb", "talloc", "replace", "tevent", "pidl" ]
+defaulttasks = [ "ctdb",
+                 "samba",
+                 "samba-xc",
+                 "samba-o3",
+                 "samba-ctdb",
+                 "samba-libs",
+                 "samba-static",
+                 "samba-systemkrb5",
+                 "samba-nopython",
+                 "ldb",
+                 "tdb",
+                 "talloc",
+                 "replace",
+                 "tevent",
+                 "pidl" ]
 
 if os.environ.get("AUTOBUILD_SKIP_SAMBA_O3", "0") == "1":
     defaulttasks.remove("samba-o3")

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -25,6 +25,7 @@ cleanup_list = []
 builddirs = {
     "ctdb"    : "ctdb",
     "samba"  : ".",
+    "samba-nt4"  : ".",
     "samba-xc" : ".",
     "samba-o3" : ".",
     "samba-ctdb" : ".",
@@ -46,6 +47,7 @@ builddirs = {
 
 defaulttasks = [ "ctdb",
                  "samba",
+                 "samba-nt4",
                  "samba-xc",
                  "samba-o3",
                  "samba-ctdb",
@@ -87,13 +89,21 @@ tasks = {
                ("check-clean-tree", "../script/clean-source-tree.sh", "text/plain"),
                ("clean", "make clean", "text/plain") ],
 
-    # We have 'test' before 'install' because, 'test' should work without 'install'
+    # We have 'test' before 'install' because, 'test' should work without 'install (runs ad_dc_ntvfs and all the other envs)'
     "samba" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                 ("make", "make -j", "text/plain"),
-                ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--exclude-env=ad_dc'", "text/plain"),
+                ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--exclude-env=nt4_dc --exclude-env=nt4_member --exclude-env=ad_dc'", "text/plain"),
                 ("install", "make install", "text/plain"),
                 ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                 ("clean", "make clean", "text/plain") ],
+
+    # We split out this so the isolated nt4_dc tests do not wait for ad_dc or ad_dc_ntvfs tests (which are long)
+    "samba-nt4" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                       ("make", "make -j", "text/plain"),
+                       ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=nt4_dc --include-env=nt4_member'", "text/plain"),
+                       ("install", "make install", "text/plain"),
+                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
+                       ("clean", "make clean", "text/plain") ],
 
     "samba-test-only" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab  --abi-check-disable" + samba_configure_params, "text/plain"),
                           ("make", "make -j", "text/plain"),

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -33,6 +33,7 @@ builddirs = {
     "samba-static"  : ".",
     "samba-test-only"  : ".",
     "samba-none-env"  : ".",
+    "samba-ad-dc"  : ".",
     "samba-systemkrb5"  : ".",
     "samba-nopython"  : ".",
     "ldb"     : "lib/ldb",
@@ -55,6 +56,7 @@ defaulttasks = [ "ctdb",
                  "samba-libs",
                  "samba-static",
                  "samba-none-env",
+                 "samba-ad-dc",
                  "samba-systemkrb5",
                  "samba-nopython",
                  "ldb",
@@ -111,6 +113,13 @@ tasks = {
                        ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                        ("clean", "make clean", "text/plain") ],
 
+    # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
+    "samba-ad-dc" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
+                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("make", "make -j", "text/plain"),
+                      ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=ad_dc'", "text/plain"),
+                      ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],
+
     "samba-test-only" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab  --abi-check-disable" + samba_configure_params, "text/plain"),
                           ("make", "make -j", "text/plain"),
                           ("test", 'make test FAIL_IMMEDIATELY=1 TESTS="${TESTS}"',"text/plain") ],
@@ -123,11 +132,10 @@ tasks = {
                     " --cross-answers=./bin-xe/cross-answers.txt --with-selftest-prefix=./bin-xa/ab" + samba_configure_params, "text/plain"),
                    ("compare-results", "script/compare_cc_results.py ./bin/c4che/default.cache.py ./bin-xe/c4che/default.cache.py ./bin-xa/c4che/default.cache.py", "text/plain")],
 
-    # test build with -O3 -- catches extra warnings and bugs, tests the ad_dc environment
+    # test build with -O3 -- catches extra warnings and bugs
     "samba-o3" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
                    ("configure", "ADDITIONAL_CFLAGS='-O3' ./configure.developer --with-selftest-prefix=./bin/ab --abi-check-disable" + samba_configure_params, "text/plain"),
                    ("make", "make -j", "text/plain"),
-                   ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=ad_dc'", "text/plain"),
                    ("install", "make install", "text/plain"),
                    ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                    ("clean", "make clean", "text/plain") ],

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -118,7 +118,7 @@ tasks = {
 
     # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
     "samba-fileserver" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
-                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("configure", "./configure.developer --without-ad-dc --without-ads --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                       ("make", "make -j", "text/plain"),
                       ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=fileserver'", "text/plain"),
                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -32,6 +32,7 @@ builddirs = {
     "samba-libs"  : ".",
     "samba-static"  : ".",
     "samba-test-only"  : ".",
+    "samba-none-env"  : ".",
     "samba-systemkrb5"  : ".",
     "samba-nopython"  : ".",
     "ldb"     : "lib/ldb",
@@ -53,6 +54,7 @@ defaulttasks = [ "ctdb",
                  "samba-ctdb",
                  "samba-libs",
                  "samba-static",
+                 "samba-none-env",
                  "samba-systemkrb5",
                  "samba-nopython",
                  "ldb",
@@ -92,7 +94,11 @@ tasks = {
     # We have 'test' before 'install' because, 'test' should work without 'install (runs ad_dc_ntvfs and all the other envs)'
     "samba" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                 ("make", "make -j", "text/plain"),
-                ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--exclude-env=nt4_dc --exclude-env=nt4_member --exclude-env=ad_dc'", "text/plain"),
+                ("test", "make test FAIL_IMMEDIATELY=1 "
+                 "TESTS='--exclude-env=nt4_dc "
+                 "--exclude-env=nt4_member "
+                 "--exclude-env=ad_dc --exclude-env=none'",
+                 "text/plain"),
                 ("install", "make install", "text/plain"),
                 ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                 ("clean", "make clean", "text/plain") ],
@@ -174,6 +180,15 @@ tasks = {
                       ("allshared-distclean", "make distclean", "text/plain"),
                       ("allshared-configure", samba_libs_configure_samba + " --with-shared-modules=ALL", "text/plain"),
                       ("allshared-make", "make -j", "text/plain")],
+
+    "samba-none-env" : [
+                      ("random-sleep", "script/random-sleep.sh 60 600", "text/plain"),
+                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("make", "make -j", "text/plain"),
+                      ("test", "make test "
+                       "FAIL_IMMEDIATELY=1 "
+                       "TESTS='--include-env=none'",
+                       "text/plain")],
 
     "samba-static" : [
                       ("random-sleep", "script/random-sleep.sh 60 600", "text/plain"),

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -90,7 +90,7 @@ tasks = {
     # We have 'test' before 'install' because, 'test' should work without 'install'
     "samba" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                 ("make", "make -j", "text/plain"),
-                ("test", "make test FAIL_IMMEDIATELY=1", "text/plain"),
+                ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--exclude-env=ad_dc'", "text/plain"),
                 ("install", "make install", "text/plain"),
                 ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                 ("clean", "make clean", "text/plain") ],
@@ -107,11 +107,11 @@ tasks = {
                     " --cross-answers=./bin-xe/cross-answers.txt --with-selftest-prefix=./bin-xa/ab" + samba_configure_params, "text/plain"),
                    ("compare-results", "script/compare_cc_results.py ./bin/c4che/default.cache.py ./bin-xe/c4che/default.cache.py ./bin-xa/c4che/default.cache.py", "text/plain")],
 
-    # test build with -O3 -- catches extra warnings and bugs, tests the ad_dc environments
+    # test build with -O3 -- catches extra warnings and bugs, tests the ad_dc environment
     "samba-o3" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
                    ("configure", "ADDITIONAL_CFLAGS='-O3' ./configure.developer --with-selftest-prefix=./bin/ab --abi-check-disable" + samba_configure_params, "text/plain"),
                    ("make", "make -j", "text/plain"),
-                   ("test", "make quicktest FAIL_IMMEDIATELY=1 TESTS='--include-env=ad_dc'", "text/plain"),
+                   ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=ad_dc'", "text/plain"),
                    ("install", "make install", "text/plain"),
                    ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                    ("clean", "make clean", "text/plain") ],

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -26,6 +26,7 @@ builddirs = {
     "ctdb"    : "ctdb",
     "samba"  : ".",
     "samba-nt4"  : ".",
+    "samba-fileserver"  : ".",
     "samba-xc" : ".",
     "samba-o3" : ".",
     "samba-ctdb" : ".",
@@ -50,6 +51,7 @@ builddirs = {
 defaulttasks = [ "ctdb",
                  "samba",
                  "samba-nt4",
+                 "samba-fileserver",
                  "samba-xc",
                  "samba-o3",
                  "samba-ctdb",
@@ -99,6 +101,7 @@ tasks = {
                 ("test", "make test FAIL_IMMEDIATELY=1 "
                  "TESTS='--exclude-env=nt4_dc "
                  "--exclude-env=nt4_member "
+                 "--exclude-env=fileserver "
                  "--exclude-env=ad_dc --exclude-env=none'",
                  "text/plain"),
                 ("install", "make install", "text/plain"),
@@ -112,6 +115,13 @@ tasks = {
                        ("install", "make install", "text/plain"),
                        ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                        ("clean", "make clean", "text/plain") ],
+
+    # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
+    "samba-fileserver" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
+                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("make", "make -j", "text/plain"),
+                      ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=fileserver'", "text/plain"),
+                      ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],
 
     # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
     "samba-ad-dc" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),

--- a/selftest/Subunit.pm
+++ b/selftest/Subunit.pm
@@ -16,6 +16,7 @@
 
 package Subunit;
 use POSIX;
+use Time::HiRes;
 
 require Exporter;
 @ISA = qw(Exporter);
@@ -43,10 +44,11 @@ sub end_test($$;$)
 	}
 }
 
-sub report_time($)
+sub report_time()
 {
 	my ($time) = @_;
-	my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst) = localtime($time);
+  $time = Time::HiRes::time() unless (defined($time));
+	my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst) = gmtime($time);
 	$sec = ($time - int($time) + $sec);
 	my $msg = sprintf("%f", $sec);
 	if (substr($msg, 1, 1) eq ".") {

--- a/selftest/selftest.pl
+++ b/selftest/selftest.pl
@@ -939,6 +939,19 @@ sub setup_env($$)
 
 	$option = "client" if $option eq "";
 
+	# Initially clear out the environment for the provision, so previous envs'
+	# variables don't leak in. Provisioning steps must explicitly set their
+	# necessary variables when calling out to other executables
+	foreach (@exported_envvars) {
+		unless ($_ == "NSS_WRAPPER_HOSTS" ||
+		        $_ == "RESOLV_WRAPPER_HOSTS")
+		{
+			delete $ENV{$_};
+		}
+	}
+	delete $ENV{SOCKET_WRAPPER_DEFAULT_IFACE};
+	delete $ENV{SMB_CONF_PATH};
+
 	$ENV{KRB5CCNAME} = "FILE:${selftest_krbt_ccache_path}.${envname}/ignore";
 
 	if (defined(get_running_env($envname))) {

--- a/selftest/selftest.pl
+++ b/selftest/selftest.pl
@@ -28,6 +28,7 @@ use lib "$RealBin";
 use Subunit;
 use SocketWrapper;
 use target::Samba;
+use Time::HiRes qw(time);
 
 eval {
 require Time::HiRes;
@@ -150,9 +151,9 @@ sub run_testsuite($$$$$)
 
 	Subunit::start_testsuite($name);
 	Subunit::progress_push();
-	Subunit::report_time(time());
+	Subunit::report_time();
 	system($cmd);
-	Subunit::report_time(time());
+	Subunit::report_time();
 	Subunit::progress_pop();
 
 	if ($? == -1) {
@@ -781,7 +782,7 @@ my $suitestotal = $#todo + 1;
 
 unless ($opt_list) {
 	Subunit::progress($suitestotal);
-	Subunit::report_time(time());
+	Subunit::report_time();
 }
 
 my $i = 0;

--- a/source3/libnet/libnet_join.c
+++ b/source3/libnet/libnet_join.c
@@ -2653,9 +2653,10 @@ static WERROR libnet_DomainJoin(TALLOC_CTX *mem_ctx,
 		DEBUG(5, ("failed to precreate account in ou %s: %s",
 			r->in.account_ou, ads_errstr(ads_status)));
 	}
+ rpc_join:
+
 #endif /* HAVE_ADS */
 
- rpc_join:
 	if ((r->in.join_flags & WKSSVC_JOIN_FLAGS_JOIN_UNSECURE) &&
 	    (r->in.join_flags & WKSSVC_JOIN_FLAGS_MACHINE_PWD_PASSED)) {
 		status = libnet_join_joindomain_rpc_unsecure(mem_ctx, r, cli);

--- a/source3/libsmb/namequery_dc.c
+++ b/source3/libsmb/namequery_dc.c
@@ -32,7 +32,7 @@
  Is this our primary domain ?
 **********************************************************************/
 
-#ifdef HAVE_KRB5
+#ifdef HAVE_ADS
 static bool is_our_primary_domain(const char *domain)
 {
 	int role = lp_server_role();

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -519,7 +519,6 @@ for t in tests:
         plansmbtorture4testsuite(t, "simpleserver", '//$SERVER/tmp -U$USERNAME%$PASSWORD')
     elif t == "smb2.notify":
         plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/tmp -U$USERNAME%$PASSWORD --signing=required')
-        plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD --signing=required')
     elif t == "smb2.dosmode":
         plansmbtorture4testsuite(t, "simpleserver", '//$SERVER/dosmode -U$USERNAME%$PASSWORD')
     elif t == "smb2.kernel-oplocks":

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -404,7 +404,7 @@ vfs = ["vfs.fruit", "vfs.acl_xattr", "vfs.fruit_netatalk", "vfs.fruit_file_id", 
 tests= base + raw + smb2 + rpc + unix + local + rap + nbt + libsmbclient + idmap + vfs
 
 for t in tests:
-    if t == "base.delaywrite":
+    if t == "base.delaywrite" or t == "base.deny1" or t == "base.deny2":
         plansmbtorture4testsuite(t, "fileserver", '//$SERVER/tmp -U$USERNAME%$PASSWORD --maximum-runtime=900')
     elif t == "base.createx_access":
         plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD -k yes --maximum-runtime=900')

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -85,7 +85,7 @@ tests = ["FDPASS", "LOCK1", "LOCK2", "LOCK3", "LOCK4", "LOCK5", "LOCK6", "LOCK7"
         "BAD-NBT-SESSION"]
 
 for t in tests:
-    plantestsuite("samba3.smbtorture_s3.plain(nt4_dc).%s" % t, "nt4_dc", [os.path.join(samba3srcdir, "script/tests/test_smbtorture_s3.sh"), t, '//$SERVER_IP/tmp', '$USERNAME', '$PASSWORD', smbtorture3, "", "-l $LOCAL_PATH"])
+    plantestsuite("samba3.smbtorture_s3.plain(fileserver).%s" % t, "fileserver", [os.path.join(samba3srcdir, "script/tests/test_smbtorture_s3.sh"), t, '//$SERVER_IP/tmp', '$USERNAME', '$PASSWORD', smbtorture3, "", "-l $LOCAL_PATH"])
     plantestsuite("samba3.smbtorture_s3.crypt_client(nt4_dc).%s" % t, "nt4_dc", [os.path.join(samba3srcdir, "script/tests/test_smbtorture_s3.sh"), t, '//$SERVER_IP/tmp', '$USERNAME', '$PASSWORD', smbtorture3, "-e", "-l $LOCAL_PATH"])
     if t == "TORTURE":
         # this is a negative test to verify that the server rejects

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -405,7 +405,7 @@ tests= base + raw + smb2 + rpc + unix + local + rap + nbt + libsmbclient + idmap
 
 for t in tests:
     if t == "base.delaywrite":
-        plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD -k yes --maximum-runtime=900')
+        plansmbtorture4testsuite(t, "fileserver", '//$SERVER/tmp -U$USERNAME%$PASSWORD --maximum-runtime=900')
     elif t == "base.createx_access":
         plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD -k yes --maximum-runtime=900')
     elif t == "rap.sam":

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -609,8 +609,9 @@ planpythontestsuite("ad_dc:local", "samba.tests.samba_tool.ntacl")
 planpythontestsuite("none", "samba.tests.samba_tool.provision_password_check")
 planpythontestsuite("none", "samba.tests.samba_tool.help")
 
-planpythontestsuite("ad_dc:local", "samba.tests.samba_tool.sites")
-planpythontestsuite("ad_dc:local", "samba.tests.samba_tool.dnscmd")
+# Run these against fl2008r2dc to share the runtime load
+planpythontestsuite("fl2008r2dc:local", "samba.tests.samba_tool.sites")
+planpythontestsuite("fl2008r2dc:local", "samba.tests.samba_tool.dnscmd")
 
 planpythontestsuite("ad_dc_ntvfs:local", "samba.tests.dcerpc.rpcecho")
 planoldpythontestsuite("ad_dc_ntvfs:local", "samba.tests.dcerpc.registry", extra_args=['-U"$USERNAME%$PASSWORD"'])

--- a/source4/torture/rpc/witness.c
+++ b/source4/torture/rpc/witness.c
@@ -790,9 +790,9 @@ static void torture_subunit_report_time(struct torture_context *tctx)
 		return;
 	}
 
-	tmp = localtime(&tp.tv_sec);
+	tmp = gmtime(&tp.tv_sec);
 	if (!tmp) {
-		torture_comment(tctx, "failed to call localtime");
+		torture_comment(tctx, "failed to call gmtime");
 		return;
 	}
 


### PR DESCRIPTION
I finally have a set of tests that pass a on travis-ci, covering more than just quicktest of ad_dc.

This runs all the nt4_dc and nt4_member tests, the ad_dc tests and most importantly the 'none' environment, where the python unit tests are written.

I plan to tidy up the commits, so this is just a preview, but the purpose is to make it easy for folks outside the Samba Team to get comprehensive CI on proposed changes. 

As a side-effect the build is more parallel so will run faster even for the full build.