### PR TITLE
use tracker-sparql-2.0 to build on ubuntu 18.04

### DIFF
--- a/source3/wscript
+++ b/source3/wscript
@@ -1616,7 +1616,7 @@ main() {
         if not conf.env['FLEX']:
             conf.fatal("Spotlight support requested but flex missing")
         conf.CHECK_COMMAND('%s --version' % conf.env['FLEX'], msg='Using flex version', define=None, on_target=False)
-        versions = ['1.0', '0.16', '0.14']
+        versions = ['1.0', '0.16', '0.14', '2.0']
         for version in versions:
             testlib = 'tracker-sparql-' + version
             if conf.CHECK_CFG(package=testlib,


### PR DESCRIPTION
fix build error in ubuntu 18.04: Spotlight support requested but tracker-sparql library missing

Ubuntu 18.04 shipped with tracker-sparql-2.0.

tested on Ubuntu 18.04 X86_64.

