### PR TITLE
Update per discussion on samba mailing list

### DIFF
--- a/docs-xml/manpages/vfs_aio_pthread.8.xml
+++ b/docs-xml/manpages/vfs_aio_pthread.8.xml
@@ -41,25 +41,28 @@
 	descriptor which essentially makes Posix AIO useless on systems
 	using the glibc implementation.</para>
 
-	<para>To work around all these limitations, the aio_pthread module
-	was written. It uses a pthread pool instead of the
-	internal Posix AIO interface to allow read and write calls
-	to be process asynchronously. A pthread pool is created
-	which expands dynamically by creating new threads as work is
-	given to it to a maximum of 100 threads per smbd process.
-	To change this limit see the "aio num threads" parameter
-	below. New threads are not created if idle threads are
-	available when a new read or write request is received,
-	the new work is given to an existing idle thread. Threads
-	terminate themselves if idle for one second.
+	<para>
+	To work around all these limitations, the aio_pthread module uses a 
+	pthread pool instead of the internal Posix AIO interface. This allows read 
+	and write calls to be process asynchronously and more efficiently. The
+	pthread pool expands dynamically by creating new threads as work is
+	given to it. A maximum of 100 threads per smbd process is set by default;
+	this limit can be changed using the <command>aio max threads</command>
+	or <command>aio_threads:aio num threads</command> parameter. If idle 
+	threads are available when a new read or write request is received, the
+	new work is given to an existing idle thread and a new thread is not
+	created. Threads terminate if idle for one second.
 	</para>
 
 	<para>
-	Note that the smb.conf parameters <command>aio read size</command>
-	and <command>aio write size</command> must also be set appropriately
-	for this module to be active.
+	Note that the smb.conf parameters <command>aio read size</command> and
+	<command>aio write size</command> must also be set appropriately for this
+	module to be active. Historically a value of 1024 was suggested for each, to work
+	around a bug in MacOS SMB2 that prevented symlinks from being written. As async
+	writes are now always handled correctly, the only reasonable values are currently
+	0 (no async I/O) and 1 (always do async I/O).
 	</para>
-
+	
 	<para>This module MUST be listed last in any module stack as
 	the Samba VFS pread/pwrite interface is not thread-safe. This
 	module makes direct pread and pwrite system calls and does


### PR DESCRIPTION
1) resolves the conflicting advice where this file recommended 1024 but the smb.conf file recommended 0 or 1 (see mailing list for discussion)

2) simplify and clean up some of the other text without changing meanings.