### PR TITLE
Make Samba autobuild more parallel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ build_samba_fileserver:
   stage: build
   tags:
     - docker
-    - shared
+    - private
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-fileserver --verbose --tail --testbase /tmp/samba-testbase

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ build_samba:
   stage: build
   tags:
     - docker
+    - private
   script:
     # this one takes about 4 hours to finish
     - python script/autobuild.py samba            --verbose --tail --testbase /tmp/samba-testbase
@@ -25,7 +26,8 @@ build_samba:
 build_samba_nt4:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - private
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
@@ -33,7 +35,8 @@ build_samba_nt4:
 build_samba_fileserver:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - shared
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-fileserver --verbose --tail --testbase /tmp/samba-testbase
@@ -41,7 +44,8 @@ build_samba_fileserver:
 build_samba_ad_dc:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - private
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-ad-dc     --verbose --tail --testbase /tmp/samba-testbase
@@ -49,7 +53,8 @@ build_samba_ad_dc:
 build_samba_none_env:
   stage: build
   tags:
-    - autobuild
+    - docker
+    - shared
   script:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-none-env    --verbose --tail --testbase /tmp/samba-testbase
@@ -58,6 +63,7 @@ build_samba_others:
   stage: build
   tags:
     - docker
+    - shared
   script:
     - python script/autobuild.py samba-nopython   --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py samba-systemkrb5 --verbose --tail --testbase /tmp/samba-testbase
@@ -70,6 +76,7 @@ build_ctdb:
   stage: build
   tags:
     - docker
+    - shared
   script:
     - python script/autobuild.py samba-ctdb       --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py ctdb             --verbose --tail --testbase /tmp/samba-testbase
@@ -78,6 +85,7 @@ build_others:
   stage: build
   tags:
     - docker
+    - shared
   script:
     - python script/autobuild.py ldb              --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py pidl             --verbose --tail --testbase /tmp/samba-testbase

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,15 @@ build_samba_ad_dc:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-ad-dc     --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_ad_dc_2:
+  stage: build
+  tags:
+    - docker
+    - private
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-ad-dc-2     --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_none_env:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,12 @@
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
 before_script:
-  - echo "Build starting ..."
+  - echo "Build starting (preparing swap)..."
+  - if [ $(df -m / --output=avail | tail -n1) -gt 10240 ]; then
+      sudo dd if=/dev/zero of=/samba-swap bs=1M count=6144;
+      sudo mkswap /samba-swap;
+      sudo swapon /samba-swap;
+    fi
 
 build_samba:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,14 @@ build_samba_nt4:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_fileserver:
+  stage: build
+  tags:
+    - autobuild
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-fileserver --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_ad_dc:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,17 +68,52 @@ build_samba_none_env:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-none-env    --verbose --tail --testbase /tmp/samba-testbase
 
-build_samba_others:
+build_samba_nopython:
   stage: build
   tags:
     - docker
     - shared
   script:
     - python script/autobuild.py samba-nopython   --verbose --tail --testbase /tmp/samba-testbase
+
+build_samba_systemkrb5:
+  stage: build
+  tags:
+    - docker
+    - shared
+  script:
     - python script/autobuild.py samba-systemkrb5 --verbose --tail --testbase /tmp/samba-testbase
+
+build_samba_xc:
+  stage: build
+  tags:
+    - docker
+    - shared
+  script:
     - python script/autobuild.py samba-xc         --verbose --tail --testbase /tmp/samba-testbase
+
+build_samba_o3:
+  stage: build
+  tags:
+    - docker
+    - shared
+  script:
     - python script/autobuild.py samba-o3         --verbose --tail --testbase /tmp/samba-testbase
+
+build_samba_libs:
+  stage: build
+  tags:
+    - docker
+    - shared
+  script:
     - python script/autobuild.py samba-libs       --verbose --tail --testbase /tmp/samba-testbase
+
+build_samba_static:
+  stage: build
+  tags:
+    - docker
+    - shared
+  script:
     - python script/autobuild.py samba-static     --verbose --tail --testbase /tmp/samba-testbase
 
 build_ctdb:
@@ -88,6 +123,13 @@ build_ctdb:
     - shared
   script:
     - python script/autobuild.py samba-ctdb       --verbose --tail --testbase /tmp/samba-testbase
+
+build_samba_ctdb:
+  stage: build
+  tags:
+    - docker
+    - shared
+  script:
     - python script/autobuild.py ctdb             --verbose --tail --testbase /tmp/samba-testbase
 
 build_others:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,14 @@ build_samba_nt4:
     # this one takes about 1 hours to finish
     - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_ad_dc:
+  stage: build
+  tags:
+    - autobuild
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-ad-dc     --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_none_env:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,14 @@ build_samba:
     # this one takes about 4 hours to finish
     - python script/autobuild.py samba            --verbose --tail --testbase /tmp/samba-testbase
 
+build_samba_nt4:
+  stage: build
+  tags:
+    - autobuild
+  script:
+    # this one takes about 1 hours to finish
+    - python script/autobuild.py samba-nt4        --verbose --tail --testbase /tmp/samba-testbase
+
 build_samba_none_env:
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,10 @@
 
 image: registry.gitlab.com/samba-team/samba:latest
 
+variables:
+  GIT_STRATEGY: fetch
+  GIT_DEPTH: "3"
+
 before_script:
   - echo "Build starting (preparing swap)..."
   - if [ $(df -m / --output=avail | tail -n1) -gt 10240 ]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 # see https://docs.gitlab.com/ce/ci/yaml/README.html for all available options
 
+image: registry.gitlab.com/samba-team/samba:latest
+
 before_script:
   - echo "Build starting (preparing swap)..."
   - if [ $(df -m / --output=avail | tail -n1) -gt 10240 ]; then
@@ -11,7 +13,7 @@ before_script:
 build_samba:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     # this one takes about 4 hours to finish
     - python script/autobuild.py samba            --verbose --tail --testbase /tmp/samba-testbase
@@ -27,7 +29,7 @@ build_samba_none_env:
 build_samba_others:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     - python script/autobuild.py samba-nopython   --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py samba-systemkrb5 --verbose --tail --testbase /tmp/samba-testbase
@@ -39,7 +41,7 @@ build_samba_others:
 build_ctdb:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     - python script/autobuild.py samba-ctdb       --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py ctdb             --verbose --tail --testbase /tmp/samba-testbase
@@ -47,7 +49,7 @@ build_ctdb:
 build_others:
   stage: build
   tags:
-    - autobuild
+    - docker
   script:
     - python script/autobuild.py ldb              --verbose --tail --testbase /tmp/samba-testbase
     - python script/autobuild.py pidl             --verbose --tail --testbase /tmp/samba-testbase

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - TASK=samba-nt4
   - TASK=samba-fileserver
   - TASK=samba-ad-dc
+  - TASK=samba-ad-dc-2
   - TASK=ldb
   - TASK=tdb
   - TASK=talloc

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - TASK=samba-nopython
   - TASK=samba-systemkrb5
   - TASK=samba-nt4
+  - TASK=samba-fileserver
   - TASK=samba-ad-dc
   - TASK=ldb
   - TASK=tdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - TASK=samba-nopython
   - TASK=samba-systemkrb5
   - TASK=samba-nt4
+  - TASK=samba-ad-dc
   - TASK=ldb
   - TASK=tdb
   - TASK=talloc

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - TASK=samba-none-env
   - TASK=samba-nopython
   - TASK=samba-systemkrb5
+  - TASK=samba-nt4
   - TASK=ldb
   - TASK=tdb
   - TASK=talloc

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -26,6 +26,7 @@ cleanup_list = []
 builddirs = {
     "ctdb"    : "ctdb",
     "samba"  : ".",
+    "samba-nt4"  : ".",
     "samba-xc" : ".",
     "samba-o3" : ".",
     "samba-ctdb" : ".",
@@ -48,6 +49,7 @@ builddirs = {
 
 defaulttasks = [ "ctdb",
                  "samba",
+                 "samba-nt4",
                  "samba-xc",
                  "samba-o3",
                  "samba-ctdb",
@@ -90,15 +92,24 @@ tasks = {
                ("check-clean-tree", "../script/clean-source-tree.sh", "text/plain"),
                ("clean", "make clean", "text/plain") ],
 
-    # We have 'test' before 'install' because, 'test' should work without 'install'
+    # We have 'test' before 'install' because, 'test' should work without 'install (runs ad_dc_ntvfs and all the other envs)'
     "samba" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                 ("make", "make -j", "text/plain"),
                 ("test", "make test FAIL_IMMEDIATELY=1 "
-                 "TESTS='--exclude-env=none'",
-                 "text/plain"),
+                 "TESTS='--exclude-env=none "
+                 "--exclude-env=nt4_dc "
+                 "--exclude-env=nt4_member'", "text/plain"),
                 ("install", "make install", "text/plain"),
                 ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                 ("clean", "make clean", "text/plain") ],
+
+    # We split out this so the isolated nt4_dc tests do not wait for ad_dc or ad_dc_ntvfs tests (which are long)
+    "samba-nt4" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                       ("make", "make -j", "text/plain"),
+                       ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=nt4_dc --include-env=nt4_member'", "text/plain"),
+                       ("install", "make install", "text/plain"),
+                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
+                       ("clean", "make clean", "text/plain") ],
 
     "samba-test-only" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab  --abi-check-disable" + samba_configure_params, "text/plain"),
                           ("make", "make -j", "text/plain"),

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -34,6 +34,7 @@ builddirs = {
     "samba-static"  : ".",
     "samba-test-only"  : ".",
     "samba-none-env"  : ".",
+    "samba-ad-dc"  : ".",
     "samba-systemkrb5"  : ".",
     "samba-nopython"  : ".",
     "ldb"     : "lib/ldb",
@@ -56,6 +57,7 @@ defaulttasks = [ "ctdb",
                  "samba-libs",
                  "samba-static",
                  "samba-none-env",
+                 "samba-ad-dc",
                  "samba-systemkrb5",
                  "samba-nopython",
                  "ldb",
@@ -98,7 +100,8 @@ tasks = {
                 ("test", "make test FAIL_IMMEDIATELY=1 "
                  "TESTS='--exclude-env=none "
                  "--exclude-env=nt4_dc "
-                 "--exclude-env=nt4_member'", "text/plain"),
+                 "--exclude-env=nt4_member "
+                 "--exclude-env=ad_dc ", "text/plain"),
                 ("install", "make install", "text/plain"),
                 ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                 ("clean", "make clean", "text/plain") ],
@@ -110,6 +113,13 @@ tasks = {
                        ("install", "make install", "text/plain"),
                        ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                        ("clean", "make clean", "text/plain") ],
+
+    # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
+    "samba-ad-dc" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
+                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("make", "make -j", "text/plain"),
+                      ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=ad_dc'", "text/plain"),
+                      ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],
 
     "samba-test-only" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab  --abi-check-disable" + samba_configure_params, "text/plain"),
                           ("make", "make -j", "text/plain"),

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -36,6 +36,7 @@ builddirs = {
     "samba-test-only"  : ".",
     "samba-none-env"  : ".",
     "samba-ad-dc"  : ".",
+    "samba-ad-dc-2"  : ".",
     "samba-systemkrb5"  : ".",
     "samba-nopython"  : ".",
     "ldb"     : "lib/ldb",
@@ -60,6 +61,7 @@ defaulttasks = [ "ctdb",
                  "samba-static",
                  "samba-none-env",
                  "samba-ad-dc",
+                 "samba-ad-dc-2",
                  "samba-systemkrb5",
                  "samba-nopython",
                  "ldb",
@@ -104,6 +106,9 @@ tasks = {
                  "--exclude-env=nt4_dc "
                  "--exclude-env=nt4_member "
                  "--exclude-env=ad_dc "
+                 "--exclude-env=chgdcpass "
+                 "--exclude-env=vampire_2000_dc "
+                 "--exclude-env=fl2000dc "
                  "--exclude-env=fileserver'",
                  "text/plain"),
                 ("install", "make install", "text/plain"),
@@ -130,6 +135,13 @@ tasks = {
                       ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                       ("make", "make -j", "text/plain"),
                       ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=ad_dc'", "text/plain"),
+                      ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],
+
+    # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
+    "samba-ad-dc-2" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
+                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("make", "make -j", "text/plain"),
+                      ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=chgdcpass --include-env=vampire_2000_dc --include-env=fl2000dc'", "text/plain"),
                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],
 
     "samba-test-only" : [ ("configure", "./configure.developer --with-selftest-prefix=./bin/ab  --abi-check-disable" + samba_configure_params, "text/plain"),

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -27,6 +27,7 @@ builddirs = {
     "ctdb"    : "ctdb",
     "samba"  : ".",
     "samba-nt4"  : ".",
+    "samba-fileserver"  : ".",
     "samba-xc" : ".",
     "samba-o3" : ".",
     "samba-ctdb" : ".",
@@ -51,6 +52,7 @@ builddirs = {
 defaulttasks = [ "ctdb",
                  "samba",
                  "samba-nt4",
+                 "samba-fileserver",
                  "samba-xc",
                  "samba-o3",
                  "samba-ctdb",
@@ -101,7 +103,9 @@ tasks = {
                  "TESTS='--exclude-env=none "
                  "--exclude-env=nt4_dc "
                  "--exclude-env=nt4_member "
-                 "--exclude-env=ad_dc ", "text/plain"),
+                 "--exclude-env=ad_dc "
+                 "--exclude-env=fileserver'",
+                 "text/plain"),
                 ("install", "make install", "text/plain"),
                 ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                 ("clean", "make clean", "text/plain") ],
@@ -113,6 +117,13 @@ tasks = {
                        ("install", "make install", "text/plain"),
                        ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
                        ("clean", "make clean", "text/plain") ],
+
+    # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
+    "samba-fileserver" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
+                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("make", "make -j", "text/plain"),
+                      ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=fileserver'", "text/plain"),
+                      ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],
 
     # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
     "samba-ad-dc" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -106,6 +106,11 @@ tasks = {
                  "--exclude-env=nt4_dc "
                  "--exclude-env=nt4_member "
                  "--exclude-env=ad_dc "
+                 "--exclude-env=fl2003dc "
+                 "--exclude-env=fl2008r2dc "
+                 "--exclude-env=ad_member "
+                 "--exclude-env=ad_member_idmap_rid "
+                 "--exclude-env=ad_member_idmap_ad "
                  "--exclude-env=chgdcpass "
                  "--exclude-env=vampire_2000_dc "
                  "--exclude-env=fl2000dc "
@@ -134,7 +139,13 @@ tasks = {
     "samba-ad-dc" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
                       ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                       ("make", "make -j", "text/plain"),
-                      ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=ad_dc'", "text/plain"),
+                      ("test", "make test FAIL_IMMEDIATELY=1 TESTS='"
+                       "--include-env=ad_dc "
+                       "--include-env=fl2003dc "
+                       "--include-env=fl2008r2dc "
+                       "--include-env=ad_member "
+                       "--include-env=ad_member_idmap_rid "
+                       "--include-env=ad_member_idmap_ad'", "text/plain"),
                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],
 
     # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -120,7 +120,7 @@ tasks = {
 
     # We split out this so the isolated ad_dc tests do not wait for ad_dc_ntvfs tests (which are long)
     "samba-fileserver" : [ ("random-sleep", "../script/random-sleep.sh 60 600", "text/plain"),
-                      ("configure", "./configure.developer --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
+                      ("configure", "./configure.developer --without-ad-dc --without-ads --with-selftest-prefix=./bin/ab" + samba_configure_params, "text/plain"),
                       ("make", "make -j", "text/plain"),
                       ("test", "make test FAIL_IMMEDIATELY=1 TESTS='--include-env=fileserver'", "text/plain"),
                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain")],

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -488,7 +488,8 @@ for t in tests:
     elif t == "smb2.lock":
         plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/aio -U$USERNAME%$PASSWORD', 'aio')
         plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/tmp -U$USERNAME%$PASSWORD')
-        plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD')
+    elif t == "raw.lock" or t == "base.lock":
+        plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/tmp -U$USERNAME%$PASSWORD')
     elif t == "raw.read":
         plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/tmp -U$USERNAME%$PASSWORD')
         plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/aio -U$USERNAME%$PASSWORD', 'aio')

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -519,7 +519,6 @@ for t in tests:
         plansmbtorture4testsuite(t, "simpleserver", '//$SERVER/tmp -U$USERNAME%$PASSWORD')
     elif t == "smb2.notify":
         plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/tmp -U$USERNAME%$PASSWORD --signing=required')
-        plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD --signing=required')
     elif t == "smb2.dosmode":
         plansmbtorture4testsuite(t, "simpleserver", '//$SERVER/dosmode -U$USERNAME%$PASSWORD')
     elif t == "smb2.kernel-oplocks":

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -404,7 +404,7 @@ vfs = ["vfs.fruit", "vfs.acl_xattr", "vfs.fruit_netatalk", "vfs.fruit_file_id", 
 tests= base + raw + smb2 + rpc + unix + local + rap + nbt + libsmbclient + idmap + vfs
 
 for t in tests:
-    if t == "base.delaywrite":
+    if t == "base.delaywrite" or t == "base.deny1" or t == "base.deny2":
         plansmbtorture4testsuite(t, "fileserver", '//$SERVER/tmp -U$USERNAME%$PASSWORD --maximum-runtime=900')
     elif t == "base.createx_access":
         plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD -k yes --maximum-runtime=900')

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -517,7 +517,8 @@ for t in tests:
             plansmbtorture4testsuite(t, env, '//$SERVER/tmp -U$USERNAME%$PASSWORD')
     elif t == "smb2.change_notify_disabled":
         plansmbtorture4testsuite(t, "simpleserver", '//$SERVER/tmp -U$USERNAME%$PASSWORD')
-    elif t == "smb2.notify":
+    elif t == "smb2.notify" or t == "raw.notify" or t == "smb2.oplock" or t == "raw.oplock":
+        # These tests are a little slower so don't duplicate them with ad_dc
         plansmbtorture4testsuite(t, "nt4_dc", '//$SERVER_IP/tmp -U$USERNAME%$PASSWORD --signing=required')
     elif t == "smb2.dosmode":
         plansmbtorture4testsuite(t, "simpleserver", '//$SERVER/dosmode -U$USERNAME%$PASSWORD')

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -85,7 +85,7 @@ tests = ["FDPASS", "LOCK1", "LOCK2", "LOCK3", "LOCK4", "LOCK5", "LOCK6", "LOCK7"
         "BAD-NBT-SESSION"]
 
 for t in tests:
-    plantestsuite("samba3.smbtorture_s3.plain(nt4_dc).%s" % t, "nt4_dc", [os.path.join(samba3srcdir, "script/tests/test_smbtorture_s3.sh"), t, '//$SERVER_IP/tmp', '$USERNAME', '$PASSWORD', smbtorture3, "", "-l $LOCAL_PATH"])
+    plantestsuite("samba3.smbtorture_s3.plain(fileserver).%s" % t, "fileserver", [os.path.join(samba3srcdir, "script/tests/test_smbtorture_s3.sh"), t, '//$SERVER_IP/tmp', '$USERNAME', '$PASSWORD', smbtorture3, "", "-l $LOCAL_PATH"])
     plantestsuite("samba3.smbtorture_s3.crypt_client(nt4_dc).%s" % t, "nt4_dc", [os.path.join(samba3srcdir, "script/tests/test_smbtorture_s3.sh"), t, '//$SERVER_IP/tmp', '$USERNAME', '$PASSWORD', smbtorture3, "-e", "-l $LOCAL_PATH"])
     if t == "TORTURE":
         # this is a negative test to verify that the server rejects

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -405,7 +405,7 @@ tests= base + raw + smb2 + rpc + unix + local + rap + nbt + libsmbclient + idmap
 
 for t in tests:
     if t == "base.delaywrite":
-        plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD -k yes --maximum-runtime=900')
+        plansmbtorture4testsuite(t, "fileserver", '//$SERVER/tmp -U$USERNAME%$PASSWORD --maximum-runtime=900')
     elif t == "base.createx_access":
         plansmbtorture4testsuite(t, "ad_dc", '//$SERVER/tmp -U$USERNAME%$PASSWORD -k yes --maximum-runtime=900')
     elif t == "rap.sam":

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -263,6 +263,8 @@ for env in ["ad_dc_ntvfs", "fl2000dc", "fl2003dc", "fl2008r2dc", "ad_dc"]:
         for bindoptions in ["connect", "krb5", "krb5,sign", "krb5,seal", "spnego", "spnego,sign", "spnego,seal"] + validate_list + ["padcheck", "bigendian", "bigendian,seal"]:
             echooptions = "--option=socket:testnonblock=True --option=torture:quick=yes -k yes"
             plansmbtorture4testsuite('rpc.echo', env, ["%s:$SERVER[%s]" % (transport, bindoptions), echooptions, '-U$USERNAME%$PASSWORD', '--workgroup=$DOMAIN'], "samba4.rpc.echo on %s with %s and %s" % (transport, bindoptions, echooptions))
+
+for env in ["fl2000dc", "fl2008r2dc"]:
     plansmbtorture4testsuite("net.api.become.dc", env, '$SERVER[%s] -U$USERNAME%%$PASSWORD -W$DOMAIN' % validate)
 
 for bindoptions in ["sign", "seal"]:

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -612,8 +612,9 @@ planpythontestsuite("ad_dc:local", "samba.tests.samba_tool.ntacl")
 planpythontestsuite("none", "samba.tests.samba_tool.provision_password_check")
 planpythontestsuite("none", "samba.tests.samba_tool.help")
 
-planpythontestsuite("ad_dc:local", "samba.tests.samba_tool.sites")
-planpythontestsuite("ad_dc:local", "samba.tests.samba_tool.dnscmd")
+# Run these against chgdcpass to share the runtime load
+planpythontestsuite("chgdcpass:local", "samba.tests.samba_tool.sites")
+planpythontestsuite("chgdcpass:local", "samba.tests.samba_tool.dnscmd")
 
 planpythontestsuite("ad_dc_ntvfs:local", "samba.tests.dcerpc.rpcecho")
 

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -625,7 +625,7 @@ planoldpythontestsuite("ad_dc:local", "samba.tests.dckeytab", extra_args=['-U"$U
 planoldpythontestsuite("ad_dc_ntvfs:local", "samba.tests.dcerpc.registry", extra_args=['-U"$USERNAME%$PASSWORD"'])
 planoldpythontestsuite("ad_dc_ntvfs", "samba.tests.dcerpc.dnsserver", extra_args=['-U"$USERNAME%$PASSWORD"'])
 planoldpythontestsuite("ad_dc", "samba.tests.dcerpc.dnsserver", extra_args=['-U"$USERNAME%$PASSWORD"'])
-planoldpythontestsuite("ad_dc", "samba.tests.dcerpc.raw_protocol", extra_args=['-U"$USERNAME%$PASSWORD"'])
+planoldpythontestsuite("chgdcpass", "samba.tests.dcerpc.raw_protocol", extra_args=['-U"$USERNAME%$PASSWORD"'])
 if have_heimdal_support:
     planoldpythontestsuite("ad_dc:local", "samba.tests.auth_log", extra_args=['-U"$USERNAME%$PASSWORD"'],
                            environ={'CLIENT_IP': '127.0.0.11',

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -978,7 +978,7 @@ plansmbtorture4testsuite('krb5.kdc', env, ['ncacn_np:$SERVER_IP', "-k", "yes", '
                          "samba4.krb5.kdc with specified account")
 
 
-for env in ["rodc", "promoted_dc", "ad_dc", "fl2000dc", "fl2008r2dc"]:
+for env in ["rodc", "promoted_dc", "fl2000dc", "fl2008r2dc"]:
     if env == "rodc":
         # The machine account is cached at the RODC, as it is the local account
         extra_options = ['--option=torture:expect_rodc=true', '--option=torture:expect_cached_at_rodc=true']


### PR DESCRIPTION
This patch series allows Samba autobuilds on sn-devel to run in about 3 hours. 

It also uses that same split-up to enable builds on Travis CI for GitHub (allowing much more comprehensive tests for new pull requests) and GitLab CI (once appropriate runners are configured). 

We also test more build combinations and include fixes for winbindd that made those tests excessively long. 

I've also compared the list of tests run between this and master and they are as expected
[test-list.diff.txt](https://github.com/samba-team/samba/files/1835777/test-list.diff.txt)

