### PR TITLE
python: Write py3 bin to correct args location

### DIFF
--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -568,7 +568,7 @@ def planoldpythontestsuite(env, module, name=None, extra_path=[], environ={}, ex
         name = module
     plantestsuite_loadlist(name, env, args)
     if py3_compatible and extra_python is not None:
-        args[0] = subunitrun3
+        args[args.index(subunitrun)] = subunitrun3
         plantestsuite_loadlist(name, env, args)
 
 


### PR DESCRIPTION
Comands written like this were working:
python /home/dmulder/code/samba/source4/scripting/bin/subunitrun
Changed to:
/usr/bin/python3 /home/dmulder/code/samba/source4/scripting/bin/subunitrun

But commands with env args overwrite the wrong arg:
CLIENT_IP=127.0.0.11 SOCKET_WRAPPER_DEFAULT_IFACE=11 python /home/dmulder/code/samba/source4/scripting/bin/subunitrun
Changed to:
/usr/bin/python3 SOCKET_WRAPPER_DEFAULT_IFACE=11 python /home/dmulder/code/samba/source4/scripting/bin/subunitrun
And were further mangled in plantestsuite_loadlist() to:
/usr/bin/python3 /home/dmulder/code/samba/source4/scripting/bin/subunitrun SOCKET_WRAPPER_DEFAULT_IFACE=11 python /home/dmulder/code/samba/source4/scripting/bin/subunitrun

Signed-off-by: David Mulder <dmulder@suse.com>