### PR TITLE
selftest/check_output: convert bytes to str for Python 3

### DIFF
--- a/python/samba/tests/blackbox/check_output.py
+++ b/python/samba/tests/blackbox/check_output.py
@@ -100,6 +100,8 @@ class CheckOutputTests(BlackboxTestCase):
         try:
             with TimeoutHelper(10):
                 actual = self.check_output(cmdline)
-                self.assertEqual(actual, expected)
+                # check_output will return bytes
+                # convert expected to bytes for python 3
+                self.assertEqual(actual, expected.encode('utf-8'))
         except TimeoutHelper.Timeout:
             self.fail(msg='Timeout!')

--- a/selftest/tests.py
+++ b/selftest/tests.py
@@ -52,7 +52,7 @@ except ImportError:
 else:
     planpythontestsuite("none", "subunit.tests.test_suite")
 planpythontestsuite("none", "samba.tests.blackbox.ndrdump")
-planpythontestsuite("none", "samba.tests.blackbox.check_output")
+planpythontestsuite("none", "samba.tests.blackbox.check_output", py3_compatible=True)
 planpythontestsuite("none", "api", name="ldb.python", extra_path=['lib/ldb/tests/python'])
 planpythontestsuite("none", "samba.tests.credentials", py3_compatible=True)
 planpythontestsuite("none", "samba.tests.registry", py3_compatible=True)


### PR DESCRIPTION
`BlackboxTestCase.check_output` will return bytes since it uses
`subprocess.communicate` underneath.
Convert expected string result to bytes for comparing.
This will be compatible for both Python 2 & 3.

Signed-off-by: Joe Guo <joeg@catalyst.net.nz>