### PR TITLE
selftest/hostconfig: fix ambiguous import for Python 3

### DIFF
--- a/python/samba/hostconfig.py
+++ b/python/samba/hostconfig.py
@@ -16,8 +16,8 @@
 #
 
 """Local host configuration."""
-
-from samdb import SamDB
+from __future__ import absolute_import
+from .samdb import SamDB
 
 class Hostconfig(object):
     """Aggregate object that contains all information about the configuration

--- a/selftest/tests.py
+++ b/selftest/tests.py
@@ -73,7 +73,7 @@ planpythontestsuite("none", "samba.tests.netcmd")
 planpythontestsuite("none", "samba.tests.dcerpc.rpc_talloc")
 planpythontestsuite("none", "samba.tests.dcerpc.array")
 planpythontestsuite("none", "samba.tests.dcerpc.string")
-planpythontestsuite("none", "samba.tests.hostconfig")
+planpythontestsuite("none", "samba.tests.hostconfig", py3_compatible=True)
 planpythontestsuite("ad_dc_ntvfs:local", "samba.tests.messaging",
                     py3_compatible=True)
 planpythontestsuite("none", "samba.tests.samba3sam")


### PR DESCRIPTION
Use relative path to import module within package and enable absolute
import.

Signed-off-by: Joe Guo <joeg@catalyst.net.nz>