### PR TITLE
Python2 python3 linkage issues rebase

### DIFF
--- a/auth/credentials/wscript_build
+++ b/auth/credentials/wscript_build
@@ -25,8 +25,11 @@ bld.SAMBA_SUBSYSTEM('CREDENTIALS_NTLM',
 	deps='samba-credentials')
 
 for env in bld.gen_python_environments():
+        pytalloc_util = bld.pyembed_libname('pytalloc-util')
+        pyparam_util = bld.pyembed_libname('pyparam_util')
+
 	bld.SAMBA_PYTHON('pycredentials',
 		source='pycredentials.c',
-		public_deps='samba-credentials cmdline-credentials pytalloc-util pyparam_util CREDENTIALS_KRB5 CREDENTIALS_SECRETS',
+		public_deps='samba-credentials cmdline-credentials %s %s CREDENTIALS_KRB5 CREDENTIALS_SECRETS' % (pytalloc_util, pyparam_util),
 		realname='samba/credentials.so'
 		)

--- a/lib/ldb-samba/wscript_build
+++ b/lib/ldb-samba/wscript_build
@@ -21,8 +21,11 @@ bld.SAMBA_SUBSYSTEM('ldbwrap',
 for env in bld.gen_python_environments():
     pyparam_util = bld.pyembed_libname('pyparam_util')
     pyldb_util = bld.pyembed_libname('pyldb-util')
+    pyauth = 'pyauth'
+    if bld.env['IS_EXTRA_PYTHON']:
+        pyauth = 'extra-' + pyauth
     bld.SAMBA_PYTHON('python_samba__ldb', 'pyldb.c',
-                     deps='ldbsamba %s ldbwrap %s pyauth' % (pyparam_util, pyldb_util),
+                     deps='ldbsamba %s ldbwrap %s %s' % (pyparam_util, pyldb_util, pyauth),
                      realname='samba/_ldb.so')
 
 bld.SAMBA_MODULE('ldbsamba_extensions',

--- a/lib/talloc/wscript
+++ b/lib/talloc/wscript
@@ -165,7 +165,7 @@ def build(bld):
 
             bld.SAMBA_PYTHON('test_pytalloc',
                             'test_pytalloc.c',
-                            deps='pytalloc',
+                            deps=name,
                             enabled=bld.PYTHON_BUILD_IS_ENABLED(),
                             realname='_test_pytalloc.so',
                             install=False)

--- a/libgpo/wscript_build
+++ b/libgpo/wscript_build
@@ -8,7 +8,8 @@ bld.SAMBA3_LIBRARY('gpext',
                    private_library=True)
 
 for env in bld.gen_python_environments():
+    pyparam_util = bld.pyembed_libname('pyparam_util')
+    pyrpc_util = bld.pyembed_libname('pyrpc_util')
     bld.SAMBA3_PYTHON('python_samba_libgpo', 'pygpo.c',
-                     deps='''pyparam_util gpext talloc ads TOKEN_UTIL
-                     auth pyrpc_util''',
+                     deps='%s gpext talloc ads TOKEN_UTIL auth %s' % (pyparam_util, pyrpc_util),
                      realname='samba/gpo.so')

--- a/python/wscript
+++ b/python/wscript
@@ -39,23 +39,21 @@ def configure(conf):
         f.close()
 
 def build(bld):
-    bld.SAMBA_LIBRARY('samba_python',
-                      source=[],
-                      deps='''
-                           LIBPYTHON
-                           pytalloc-util
-                           pyrpc_util
-                           ''',
-                      grouping_library=True,
-                      private_library=True,
-                      pyembed=True,
-                      enabled=bld.PYTHON_BUILD_IS_ENABLED())
+
 
     for env in bld.gen_python_environments():
         pytalloc_util = bld.pyembed_libname('pytalloc-util')
         pyparam_util = bld.pyembed_libname('pyparam_util')
         libpython = bld.pyembed_libname('LIBPYTHON')
-
+        pyrpc_util = bld.pyembed_libname('pyrpc_util')
+        samba_python = bld.pyembed_libname('samba_python')
+        bld.SAMBA_LIBRARY(samba_python,
+                      source=[],
+                      deps='%s %s %s' % (libpython, pytalloc_util, pyrpc_util),
+                      grouping_library=True,
+                      private_library=True,
+                      pyembed=True,
+                      enabled=bld.PYTHON_BUILD_IS_ENABLED())
         bld.SAMBA_PYTHON('python_glue',
                          source='pyglue.c',
                          deps='''

--- a/source3/wscript_build
+++ b/source3/wscript_build
@@ -1307,9 +1307,12 @@ for env in bld.gen_python_environments():
                   )
 
 for env in bld.gen_python_environments():
+    pycredentials = 'pycredentials'
+    if bld.env['IS_EXTRA_PYTHON']:
+        pycredentials = 'extra-' + pycredentials
     bld.SAMBA3_PYTHON('pylibsmb',
                   source='libsmb/pylibsmb.c',
-                  deps='smbclient samba-credentials pycredentials',
+                  deps='smbclient samba-credentials %s' % pycredentials,
                   realname='samba/samba3/libsmb_samba_internal.so'
                   )
 

--- a/source4/auth/wscript_build
+++ b/source4/auth/wscript_build
@@ -47,10 +47,13 @@ for env in bld.gen_python_environments():
 	pytalloc_util = bld.pyembed_libname('pytalloc-util')
 	pyparam_util = bld.pyembed_libname('pyparam_util')
 	pyldb_util = bld.pyembed_libname('pyldb-util')
+	pycredentials = 'pycredentials'
+        if bld.env['IS_EXTRA_PYTHON']:
+            pycredentials = 'extra-' + pycredentials
 	bld.SAMBA_PYTHON('pyauth',
 		source='pyauth.c',
 		public_deps='auth_system_session',
-		deps='samdb %s %s %s pycredentials auth4' % (pytalloc_util, pyparam_util, pyldb_util),
+		deps='samdb %s %s %s %s auth4' % (pytalloc_util, pyparam_util, pyldb_util, pycredentials),
 		realname='samba/auth.so'
 		)
 

--- a/source4/lib/messaging/wscript_build
+++ b/source4/lib/messaging/wscript_build
@@ -20,6 +20,6 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_messaging',
 		source='pymessaging.c',
-		deps='MESSAGING events pyparam_util pytalloc-util',
+		deps='MESSAGING events %s %s' % (pyparam_util, pytalloc_util),
 		realname='samba/messaging.so'
 		)

--- a/source4/lib/policy/wscript_build
+++ b/source4/lib/policy/wscript_build
@@ -1,20 +1,23 @@
 #!/usr/bin/env python
 
-bld.SAMBA_LIBRARY('samba-policy',
+
+
+for env in bld.gen_python_environments():
+    pytalloc_util = bld.pyembed_libname('pytalloc-util')
+    samba_policy = bld.pyembed_libname('samba-policy')
+    samba_net = bld.pyembed_libname('samba-net')
+    bld.SAMBA_LIBRARY(samba_policy,
 	source='gp_ldap.c gp_filesys.c gp_manage.c gp_ini.c',
 	pc_files='samba-policy.pc',
-	public_deps='ldb samba-net',
+	public_deps='ldb %s' % samba_net,
 	vnum='0.0.1',
 	pyembed=True,
 	public_headers='policy.h',
 	enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	)
-
-for env in bld.gen_python_environments():
-    pytalloc_util = bld.pyembed_libname('pytalloc-util')
     bld.SAMBA_PYTHON(
         'py_policy',
         source='pypolicy.c',
-        public_deps=' '.join(['samba-policy', pytalloc_util]),
+        public_deps='%s %s' % (samba_policy, pytalloc_util),
         realname='samba/policy.so'
     )

--- a/source4/libnet/wscript_build
+++ b/source4/libnet/wscript_build
@@ -20,7 +20,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_dckeytab',
 		source='py_net_dckeytab.c libnet_export_keytab.c',
-		deps='pyrpc_util db-glue krb5 com_err',
+		deps='%s db-glue krb5 com_err' % (pyrpc_util),
 		realname='samba/dckeytab.so',
 		enabled=bld.CONFIG_SET('AD_DC_BUILD_IS_ENABLED')
 		)

--- a/source4/libnet/wscript_build
+++ b/source4/libnet/wscript_build
@@ -1,20 +1,25 @@
 #!/usr/bin/env python
 
-bld.SAMBA_LIBRARY('samba-net',
-	source='libnet.c libnet_passwd.c libnet_time.c libnet_rpc.c libnet_join.c libnet_site.c libnet_become_dc.c libnet_unbecome_dc.c libnet_vampire.c libnet_samdump.c libnet_samsync_ldb.c libnet_user.c libnet_group.c libnet_share.c libnet_lookup.c libnet_domain.c userinfo.c groupinfo.c userman.c groupman.c prereq_domain.c libnet_samsync.c',
-	autoproto='libnet_proto.h',
-	public_deps='samba-credentials dcerpc dcerpc-samr RPC_NDR_LSA RPC_NDR_SRVSVC RPC_NDR_DRSUAPI cli_composite LIBCLI_RESOLVE LIBCLI_FINDDCS cli_cldap LIBCLI_FINDDCS gensec_schannel LIBCLI_AUTH ndr smbpasswdparser PROVISION LIBCLI_SAMSYNC LIBTSOCKET',
-	private_library=True,
-	enabled=bld.PYTHON_BUILD_IS_ENABLED()
-	)
-
-
 for env in bld.gen_python_environments():
 	pytalloc_util = bld.pyembed_libname('pytalloc-util')
 	pyrpc_util = bld.pyembed_libname('pyrpc_util')
+	provision = bld.pyembed_libname('PROVISION')
+	name = bld.pyembed_libname('samba-net')
+	auto_proto='libnet_proto.h'
+	if bld.env['IS_EXTRA_PYTHON']:
+		auto_proto=None
+	bld.SAMBA_LIBRARY(name,
+		source='libnet.c libnet_passwd.c libnet_time.c libnet_rpc.c libnet_join.c libnet_site.c libnet_become_dc.c libnet_unbecome_dc.c libnet_vampire.c libnet_samdump.c libnet_samsync_ldb.c libnet_user.c libnet_group.c libnet_share.c libnet_lookup.c libnet_domain.c userinfo.c groupinfo.c userman.c groupman.c prereq_domain.c libnet_samsync.c',
+		autoproto=auto_proto,
+		public_deps='samba-credentials dcerpc dcerpc-samr RPC_NDR_LSA RPC_NDR_SRVSVC RPC_NDR_DRSUAPI cli_composite LIBCLI_RESOLVE LIBCLI_FINDDCS cli_cldap LIBCLI_FINDDCS gensec_schannel LIBCLI_AUTH ndr smbpasswdparser %s LIBCLI_SAMSYNC LIBTSOCKET' % (provision),
+		private_library=True,
+		pyembed=True,
+		enabled=bld.PYTHON_BUILD_IS_ENABLED()
+		)
+
 	bld.SAMBA_PYTHON('python_net',
 		source='py_net.c',
-		deps='samba-net %s %s' % (pyrpc_util, pytalloc_util),
+		deps='%s %s %s' % (name, pyrpc_util, pytalloc_util),
 		realname='samba/net.so'
 		)
 

--- a/source4/librpc/wscript_build
+++ b/source4/librpc/wscript_build
@@ -267,28 +267,28 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_srvsvc',
 	    source='../../librpc/gen_ndr/py_srvsvc.c',
-	    deps='RPC_NDR_SRVSVC pytalloc-util pyrpc_util',
+	    deps='RPC_NDR_SRVSVC %s %s' % (pytalloc_util, pyrpc_util),
 	    realname='samba/dcerpc/srvsvc.so',
             cflags_end=gen_cflags
 	    )
 
 	bld.SAMBA_PYTHON('python_echo',
 		source='../../librpc/gen_ndr/py_echo.c',
-		deps='RPC_NDR_ECHO pytalloc-util pyrpc_util',
+		deps='RPC_NDR_ECHO %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/echo.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_dns',
 		source='../../librpc/gen_ndr/py_dns.c',
-		deps='NDR_DNS pytalloc-util pyrpc_util',
+		deps='NDR_DNS %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/dns.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_winreg',
 		source='../../librpc/gen_ndr/py_winreg.c',
-		deps='RPC_NDR_WINREG pytalloc-util pyrpc_util',
+		deps='RPC_NDR_WINREG %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/winreg.so',
                 cflags_end=gen_cflags
 		)
@@ -296,7 +296,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_initshutdown',
 		source='../../librpc/gen_ndr/py_initshutdown.c',
-		deps='RPC_NDR_INITSHUTDOWN pytalloc-util pyrpc_util',
+		deps='RPC_NDR_INITSHUTDOWN %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/initshutdown.so',
                 cflags_end=gen_cflags
 		)
@@ -304,7 +304,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_epmapper',
 		source='../../librpc/gen_ndr/py_epmapper.c',
-		deps='dcerpc pytalloc-util pyrpc_util',
+		deps='dcerpc %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/epmapper.so',
                 cflags_end=gen_cflags
 		)
@@ -312,7 +312,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_mgmt',
 		source='../../librpc/gen_ndr/py_mgmt.c',
-		deps='pytalloc-util dcerpc pyrpc_util',
+		deps='dcerpc %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/mgmt.so',
                 cflags_end=gen_cflags
 		)
@@ -320,7 +320,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_atsvc',
 		source='../../librpc/gen_ndr/py_atsvc.c',
-		deps='RPC_NDR_ATSVC pytalloc-util pyrpc_util',
+		deps='RPC_NDR_ATSVC %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/atsvc.so',
                 cflags_end=gen_cflags
 		)
@@ -328,7 +328,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_svcctl',
 		source='../../librpc/gen_ndr/py_svcctl.c',
-		deps='RPC_NDR_SVCCTL pytalloc-util pyrpc_util',
+		deps='RPC_NDR_SVCCTL %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/svcctl.so',
                 cflags_end=gen_cflags
 		)
@@ -336,7 +336,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_wkssvc',
 		source='../../librpc/gen_ndr/py_wkssvc.c',
-		deps='RPC_NDR_WKSSVC pytalloc-util pyrpc_util',
+		deps='RPC_NDR_WKSSVC %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/wkssvc.so',
                 cflags_end=gen_cflags
 		)
@@ -344,21 +344,21 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_dfs',
 		source='../../librpc/gen_ndr/py_dfs.c',
-		deps='RPC_NDR_DFS pytalloc-util pyrpc_util',
+		deps='RPC_NDR_DFS %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/dfs.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_dcerpc_dcerpc',
 		source='../../librpc/gen_ndr/py_dcerpc.c',
-		deps='NDR_DCERPC pytalloc-util pyrpc_util',
+		deps='NDR_DCERPC %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/dcerpc.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_unixinfo',
 		source='../../librpc/gen_ndr/py_unixinfo.c',
-		deps='RPC_NDR_UNIXINFO pytalloc-util pyrpc_util',
+		deps='RPC_NDR_UNIXINFO %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/unixinfo.so',
                 cflags_end=gen_cflags
 		)
@@ -373,21 +373,24 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_server_id',
 		source='../../librpc/gen_ndr/py_server_id.c',
-		deps='RPC_NDR_SERVER_ID pytalloc-util pyrpc_util',
+		deps='RPC_NDR_SERVER_ID %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/server_id.so',
                 cflags_end=gen_cflags
 		)
 
+	python_netlogon = 'python_netlogon'
+	if bld.env['IS_EXTRA_PYTHON']:
+		python_netlogon = 'extra-' + python_netlogon
 	bld.SAMBA_PYTHON('python_winbind',
 		source='../../librpc/gen_ndr/py_winbind.c',
-		deps='RPC_NDR_WINBIND pytalloc-util pyrpc_util python_netlogon',
+		deps='RPC_NDR_WINBIND %s %s %s' % (pytalloc_util, pyrpc_util, python_netlogon),
 		realname='samba/dcerpc/winbind.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_idmap',
 		source='../../librpc/gen_ndr/py_idmap.c',
-		deps='NDR_IDMAP pytalloc-util pyrpc_util',
+		deps='NDR_IDMAP %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/idmap.so',
                 cflags_end=gen_cflags
 		)
@@ -395,14 +398,14 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_drsuapi',
 		source='../../librpc/gen_ndr/py_drsuapi.c',
-		deps='RPC_NDR_DRSUAPI pytalloc-util pyrpc_util',
+		deps='RPC_NDR_DRSUAPI %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/drsuapi.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_dcerpc_dnsp',
 		source='../../librpc/gen_ndr/py_dnsp.c',
-		deps='pytalloc-util pyrpc_util NDR_SECURITY NDR_DNSP',
+		deps='%s %s NDR_SECURITY NDR_DNSP' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/dnsp.so',
                 cflags_end=gen_cflags
 		)
@@ -410,35 +413,35 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_PYTHON('python_dcerpc_xattr',
 		source='../../librpc/gen_ndr/py_xattr.c',
-		deps='pytalloc-util pyrpc_util RPC_NDR_XATTR',
+		deps='%s %s RPC_NDR_XATTR' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/xattr.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_dcerpc_idmap',
 		source='../../librpc/gen_ndr/py_idmap.c',
-		deps='pytalloc-util pyrpc_util RPC_NDR_XATTR',
+		deps='%s %s RPC_NDR_XATTR' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/idmap.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_dnsserver',
 		source='../../librpc/gen_ndr/py_dnsserver.c',
-		deps='RPC_NDR_DNSSERVER pytalloc-util pyrpc_util',
+		deps='RPC_NDR_DNSSERVER %s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/dnsserver.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('python_dcerpc_smb_acl',
 		source='../../librpc/gen_ndr/py_smb_acl.c',
-		deps='pytalloc-util pyrpc_util',
+		deps='%s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/smb_acl.so',
                 cflags_end=gen_cflags
 		)
 
 	bld.SAMBA_PYTHON('dcerpc_python_messaging',
 		source='../../librpc/gen_ndr/py_messaging.c',
-		deps='pytalloc-util pyrpc_util',
+		deps='%s %s' % (pytalloc_util, pyrpc_util),
 		realname='samba/dcerpc/messaging.so',
                 cflags_end=gen_cflags
 		)

--- a/source4/param/wscript_build
+++ b/source4/param/wscript_build
@@ -39,6 +39,7 @@ bld.SAMBA_SUBSYSTEM('SECRETS',
 for env in bld.gen_python_environments():
 	pytalloc_util = bld.pyembed_libname('pytalloc-util')
 	pyparam_util = bld.pyembed_libname('pyparam_util')
+	libpython = bld.pyembed_libname('LIBPYTHON')
 
 	bld.SAMBA_PYTHON('pyparam',
 	    source='pyparam.c',
@@ -48,7 +49,7 @@ for env in bld.gen_python_environments():
 
 	bld.SAMBA_SUBSYSTEM(pyparam_util,
 	    source='pyparam_util.c',
-	    deps='LIBPYTHON samba-hostconfig %s' % pytalloc_util,
+	    deps='%s samba-hostconfig %s' % (libpython, pytalloc_util),
 	    pyext=True,
 	    enabled=bld.PYTHON_BUILD_IS_ENABLED()
 	    )

--- a/source4/param/wscript_build
+++ b/source4/param/wscript_build
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
-
-bld.SAMBA_SUBSYSTEM('PROVISION',
-	source='provision.c pyparam.c',
-	deps='LIBPYTHON pyparam_util ldb pytalloc-util pyldb-util',
-	pyext=True,
-	enabled=bld.PYTHON_BUILD_IS_ENABLED(),
+for env in bld.gen_python_environments():
+	name = bld.pyembed_libname('PROVISION')
+	pytalloc_util = bld.pyembed_libname('pytalloc-util')
+	pyparam_util = bld.pyembed_libname('pyparam_util')
+	libpython = bld.pyembed_libname('LIBPYTHON')
+	
+	pyldb_util = bld.pyembed_libname('pyldb-util')
+	bld.SAMBA_SUBSYSTEM(name,
+		source='provision.c pyparam.c',
+		deps='%s %s ldb %s %s' % (libpython, pyparam_util, pytalloc_util, pyldb_util),
+		pyext=True,
+		enabled=bld.PYTHON_BUILD_IS_ENABLED(),
 	)
 
 


### PR DESCRIPTION
This patch set ensures any py3 (or whatever is specified with --extra-python) built components like the correct libraries and objects, e.g. any py3 c-module built shouldn't directly (or indirectly) link in something that would cause both libpython2 and libpython3 to both linked. Additionally the grouping library (which doesn't seem to be be used) is removed.
In order to ensure the correct libraries are linked a couple of subsystems and libraries that weren't built for py3 (but should have been) are now built (so they can be linked)