### PR TITLE
fix ldb-samba: require pid match for cached ldb

### DIFF
--- a/lib/ldb-samba/ldb_wrap.c
+++ b/lib/ldb-samba/ldb_wrap.c
@@ -37,6 +37,7 @@
 #include "../lib/util/dlinklist.h"
 #include "lib/util/util_paths.h"
 #include <tdb.h>
+#include <unistd.h>
 
 #undef DBGC_CLASS
 #define DBGC_CLASS DBGC_LDB


### PR DESCRIPTION
Build failing with unknown function getpid() error

Signed-off-by: David Mulder <dmulder@suse.com>