### PR TITLE
Py3 string arg handling

### DIFF
--- a/lib/ldb/pyldb.c
+++ b/lib/ldb/pyldb.c
@@ -1078,7 +1078,7 @@ static const char **PyList_AsStrList(TALLOC_CTX *mem_ctx, PyObject *list,
 		const char *str = NULL;
 		Py_ssize_t size;
 		PyObject *item = PyList_GetItem(list, i);
-		if (!PyStr_Check(item)) {
+		if (!(PyStr_Check(item) || PyUnicode_Check(item))) {
 			PyErr_Format(PyExc_TypeError, "%s should be strings", paramname);
 			talloc_free(ret);
 			return NULL;
@@ -2861,7 +2861,7 @@ static struct ldb_message_element *PyObject_AsMessageElement(
 
 	me->name = talloc_strdup(me, attr_name);
 	me->flags = flags;
-	if (PyBytes_Check(set_obj) || PyStr_Check(set_obj)) {
+	if (PyBytes_Check(set_obj) || PyUnicode_Check(set_obj)) {
 		me->num_values = 1;
 		me->values = talloc_array(me, struct ldb_val, me->num_values);
 		if (PyBytes_Check(set_obj)) {
@@ -2897,7 +2897,7 @@ static struct ldb_message_element *PyObject_AsMessageElement(
 					return NULL;
 				}
 				msg = _msg;
-			} else if (PyStr_Check(obj)) {
+			} else if (PyUnicode_Check(obj)) {
 				msg = PyStr_AsUTF8AndSize(obj, &size);
 				if (msg == NULL) {
 					talloc_free(me);
@@ -3069,7 +3069,7 @@ static PyObject *py_ldb_msg_element_new(PyTypeObject *type, PyObject *args, PyOb
 
 	if (py_elements != NULL) {
 		Py_ssize_t i;
-		if (PyBytes_Check(py_elements) || PyStr_Check(py_elements)) {
+		if (PyBytes_Check(py_elements) || PyUnicode_Check(py_elements)) {
 			char *_msg = NULL;
 			el->num_values = 1;
 			el->values = talloc_array(el, struct ldb_val, 1);
@@ -3110,7 +3110,7 @@ static PyObject *py_ldb_msg_element_new(PyTypeObject *type, PyObject *args, PyOb
 					char *_msg = NULL;
 					result = PyBytes_AsStringAndSize(item, &_msg, &size);
 					msg = _msg;
-				} else if (PyStr_Check(item)) {
+				} else if (PyUnicode_Check(item)) {
 					msg = PyStr_AsUTF8AndSize(item, &size);
 					result = (msg == NULL) ? -1 : 0;
 				} else {

--- a/lib/ldb/pyldb_util.c
+++ b/lib/ldb/pyldb_util.c
@@ -70,7 +70,7 @@ bool pyldb_Object_AsDn(TALLOC_CTX *mem_ctx, PyObject *object,
 	struct ldb_dn *odn;
 	PyTypeObject *PyLdb_Dn_Type;
 
-	if (ldb_ctx != NULL && PyStr_Check(object)) {
+	if (ldb_ctx != NULL && (PyStr_Check(object) || PyUnicode_Check(object))) {
 		odn = ldb_dn_new(mem_ctx, ldb_ctx, PyStr_AsUTF8(object));
 		*dn = odn;
 		return true;

--- a/lib/tevent/pytevent.c
+++ b/lib/tevent/pytevent.c
@@ -188,7 +188,7 @@ static PyObject *py_register_backend(PyObject *self, PyObject *args)
 		return NULL;
 	}
 
-	if (!PyStr_Check(name)) {
+	if (!(PyStr_Check(name) || PyUnicode_Check(name))) {
 		PyErr_SetNone(PyExc_TypeError);
 		Py_DECREF(name);
 		return NULL;

--- a/libcli/nbt/pynbt.c
+++ b/libcli/nbt/pynbt.c
@@ -57,7 +57,7 @@ static PyObject *py_nbt_node_init(PyTypeObject *self, PyObject *args, PyObject *
 
 static bool PyObject_AsDestinationTuple(PyObject *obj, const char **dest_addr, uint16_t *dest_port)
 {
-	if (PyStr_Check(obj)) {
+	if (PyStr_Check(obj) || PyUnicode_Check(obj)) {
 		*dest_addr = PyStr_AsString(obj);
 		*dest_port = NBT_NAME_SERVICE_PORT;
 		return true;
@@ -69,7 +69,7 @@ static bool PyObject_AsDestinationTuple(PyObject *obj, const char **dest_addr, u
 			return false;
 		}
 
-		if (!PyStr_Check(PyTuple_GetItem(obj, 0))) {
+		if (!(PyStr_Check(PyTuple_GetItem(obj, 0)) || PyUnicode_Check(PyTuple_GetItem(obj, 0)))) {
 			PyErr_SetString(PyExc_TypeError, "Destination tuple first element not string");
 			return false;
 		}
@@ -111,7 +111,7 @@ static bool PyObject_AsNBTName(PyObject *obj, struct nbt_name_socket *name_socke
 		}
 	}
 
-	if (PyStr_Check(obj)) {
+	if (PyStr_Check(obj) || PyUnicode_Check(obj)) {
 		/* FIXME: Parse string to be able to interpret things like RHONWYN<02> ? */
 		name->name = PyStr_AsString(obj);
 		name->scope = NULL;

--- a/source4/auth/pyauth.c
+++ b/source4/auth/pyauth.c
@@ -184,7 +184,7 @@ static const char **PyList_AsStringList(TALLOC_CTX *mem_ctx, PyObject *list,
 		const char *value;
 		Py_ssize_t size;
 		PyObject *item = PyList_GetItem(list, i);
-		if (!PyStr_Check(item)) {
+		if (!(PyStr_Check(item) || PyUnicode_Check(item))) {
 			PyErr_Format(PyExc_TypeError, "%s should be strings", paramname);
 			return NULL;
 		}

--- a/source4/dsdb/pydsdb.c
+++ b/source4/dsdb/pydsdb.c
@@ -580,7 +580,7 @@ static PyObject *py_dsdb_DsReplicaAttribute(PyObject *self, PyObject *args)
 
 		for (i = 0; i < el->num_values; i++) {
 			PyObject *item = PyList_GetItem(el_list, i);
-			if (!PyStr_Check(item)) {
+			if (!(PyStr_Check(item) || PyUnicode_Check(item))) {
 				PyErr_Format(PyExc_TypeError, "ldif_elements should be strings");
 				talloc_free(tmp_ctx);
 				return NULL;

--- a/source4/librpc/rpc/pyrpc.c
+++ b/source4/librpc/rpc/pyrpc.c
@@ -50,28 +50,32 @@ static bool ndr_syntax_from_py_object(PyObject *object, struct ndr_syntax_id *sy
 {
 	ZERO_STRUCTP(syntax_id);
 
-	if (PyStr_Check(object)) {
+	if (PyStr_Check(object) || PyUnicode_Check(object)) {
 		return PyString_AsGUID(object, &syntax_id->uuid);
 	} else if (PyTuple_Check(object)) {
+		PyObject *item = NULL;
 		if (PyTuple_Size(object) < 1 || PyTuple_Size(object) > 2) {
 			PyErr_SetString(PyExc_ValueError, "Syntax ID tuple has invalid size");
 			return false;
 		}
 
-		if (!PyStr_Check(PyTuple_GetItem(object, 0))) {
+		item = PyTuple_GetItem(object, 0);
+		if (!(PyStr_Check(item) || PyUnicode_Check(item))) {
 			PyErr_SetString(PyExc_ValueError, "Expected GUID as first element in tuple");
 			return false;
 		}
 
-		if (!PyString_AsGUID(PyTuple_GetItem(object, 0), &syntax_id->uuid)) 
+		if (!PyString_AsGUID(item, &syntax_id->uuid)) {
 			return false;
+		}
 
-		if (!PyInt_Check(PyTuple_GetItem(object, 1))) {
+		item = PyTuple_GetItem(object, 1);
+		if (!PyInt_Check(item)) {
 			PyErr_SetString(PyExc_ValueError, "Expected version as second element in tuple");
 			return false;
 		}
 
-		syntax_id->if_version = PyInt_AsLong(PyTuple_GetItem(object, 1));
+		syntax_id->if_version = PyInt_AsLong(item);
 		return true;
 	}
 

--- a/source4/param/pyparam.c
+++ b/source4/param/pyparam.c
@@ -456,7 +456,7 @@ static Py_ssize_t py_lp_ctx_len(PyObject *self)
 static PyObject *py_lp_ctx_getitem(PyObject *self, PyObject *name)
 {
 	struct loadparm_service *service;
-	if (!PyStr_Check(name)) {
+	if (!(PyStr_Check(name) || PyUnicode_Check(name))) {
 		PyErr_SetString(PyExc_TypeError, "Only string subscripts are supported");
 		return NULL;
 	}

--- a/source4/param/pyparam_util.c
+++ b/source4/param/pyparam_util.c
@@ -34,7 +34,7 @@ _PUBLIC_ struct loadparm_context *lpcfg_from_py_object(TALLOC_CTX *mem_ctx, PyOb
 	PyTypeObject *lp_type;
 	bool is_lpobj;
 
-	if (PyStr_Check(py_obj)) {
+	if (PyStr_Check(py_obj) || PyUnicode_Check(py_obj)) {
 		lp_ctx = loadparm_init_global(false);
 		if (lp_ctx == NULL) {
 			return NULL;


### PR DESCRIPTION
Separate out patches from pull request #161 
Many of the python c-modules don't handle unicode as string types when passed say as object. This wasn't really a problem in a python2 only world. With code ported to be python2/python3 compatible it seems (at least in code we are porting) that we now find objects that were previously string in python2 now getting passed as unicode types in python2. This is a side affect of trying to cater for variables returned from functions as 'bytes'  in python3 that are returned as 'string' in python2. We normally do something like

   py2py3compat_var.decode('utf8')

To ensure the bytes provided in python3 are converted to 'str' The same line of code when running under python2 will covert a 'str' type to 'unicode'

We really should handle 'unicode' anyway as it is a 'text type. For example python2 code that use the ParseTuplexxxx functions to handle arguments already automatically handle 'str' or 
'unicode' when passed a 'string' format. 