### PR TITLE
fix implicit declaration of function ‘getpid’

### DIFF
--- a/lib/ldb-samba/ldb_wrap.c
+++ b/lib/ldb-samba/ldb_wrap.c
@@ -37,6 +37,7 @@
 #include "../lib/util/dlinklist.h"
 #include "lib/util/util_paths.h"
 #include <tdb.h>
+#include <unistd.h>
 
 #undef DBGC_CLASS
 #define DBGC_CLASS DBGC_LDB


### PR DESCRIPTION
error happens when configure --enable-developer

Signed-off-by: Stuart Hu <hushijie@qiniu.com>