### PR TITLE
nsswitch: Add try_authok option to pam_winbind

### DIFF
--- a/docs-xml/manpages/pam_winbind.8.xml
+++ b/docs-xml/manpages/pam_winbind.8.xml
@@ -123,6 +123,14 @@
 		</varlistentry>
 
 		<varlistentry>
+		<term>try_authtok</term>
+		<listitem><para>
+		Same as the use_authtok option (previous item), except that if the new password is not
+		valid, PAM will prompt for a password.
+		</para></listitem>
+		</varlistentry>
+
+		<varlistentry>
 		<term>krb5_auth</term>
 		<listitem><para>
 

--- a/nsswitch/pam_winbind.c
+++ b/nsswitch/pam_winbind.c
@@ -492,6 +492,8 @@ config_from_pam:
 			ctrl |= WINBIND_SILENT;
 		else if (!strcasecmp(*v, "use_authtok"))
 			ctrl |= WINBIND_USE_AUTHTOK_ARG;
+		else if (!strcasecmp(*v, "try_authtok"))
+			ctrl |= WINBIND_TRY_AUTHTOK_ARG;
 		else if (!strcasecmp(*v, "use_first_pass"))
 			ctrl |= WINBIND_USE_FIRST_PASS_ARG;
 		else if (!strcasecmp(*v, "try_first_pass"))
@@ -3180,6 +3182,9 @@ int pam_sm_chauthtok(pam_handle_t * pamh, int flags,
 
 		if (on(WINBIND_USE_AUTHTOK_ARG, lctrl)) {
 			lctrl |= WINBIND_USE_FIRST_PASS_ARG;
+		}
+		if (on(WINBIND_TRY_AUTHTOK_ARG, lctrl)) {
+			lctrl |= WINBIND_TRY_FIRST_PASS_ARG;
 		}
 		retry = 0;
 		ret = PAM_AUTHTOK_ERR;

--- a/nsswitch/pam_winbind.h
+++ b/nsswitch/pam_winbind.h
@@ -156,6 +156,7 @@ do {                             \
 #define WINBIND_DEBUG_STATE		0x00001000
 #define WINBIND_WARN_PWD_EXPIRE		0x00002000
 #define WINBIND_MKHOMEDIR		0x00004000
+#define WINBIND_TRY_AUTHTOK_ARG		0x00008000
 
 #if defined(HAVE_GETTEXT) && !defined(__LCLINT__)
 #define _(string) dgettext(MODULE_NAME, string)

--- a/python/samba/tests/pam_winbind_chauthtok.py
+++ b/python/samba/tests/pam_winbind_chauthtok.py
@@ -1,0 +1,37 @@
+# Unix SMB/CIFS implementation.
+#
+# Copyright (C) 2017      Andreas Schneider <asn@samba.org>
+# Copyright (C) 2018      Mathieu Parent <math.parent@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import samba.tests
+import pypamtest
+import os
+
+class PamChauthtokTests(samba.tests.TestCase):
+    def test_chauthtok(self):
+        domain = os.environ["DOMAIN"]
+        username = os.environ["USERNAME"]
+        password = os.environ["PASSWORD"]
+        newpassword = os.environ["NEWPASSWORD"]
+        pam_options = os.environ["PAM_OPTIONS"]
+        unix_username = "%s/%s" % (domain, username)
+        expected_rc = 0 # PAM_SUCCESS
+
+        tc = pypamtest.TestCase(pypamtest.PAMTEST_CHAUTHTOK, expected_rc)
+        res = pypamtest.run_pamtest(unix_username, "samba", [tc], [password, newpassword, newpassword])
+
+        self.assertTrue(res != None)

--- a/python/samba/tests/test_pam_winbind_chauthtok.sh
+++ b/python/samba/tests/test_pam_winbind_chauthtok.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+PYTHON="$1"
+PAM_WRAPPER_SO_PATH="$2"
+shift 2
+
+DOMAIN="$1"
+export DOMAIN
+USERNAME="$2"
+export USERNAME
+PASSWORD="$3"
+export PASSWORD
+NEWPASSWORD="$4"
+export NEWPASSWORD
+PAM_OPTIONS="$5"
+export PAM_OPTIONS
+CREATE_USER="$6"
+shift 6
+
+if [ "$CREATE_USER" = yes ]; then
+    CREATE_SERVER="$1"
+    CREATE_USERNAME="$2"
+    CREATE_PASSWORD="$3"
+    shift 3
+    ./bin/samba-tool user create "$USERNAME" "$PASSWORD" -H "ldap://$CREATE_SERVER" -U "$CREATE_USERNAME%$CREATE_PASSWORD"
+fi
+
+PAM_WRAPPER_PATH="$BINDIR/default/third_party/pam_wrapper"
+
+pam_winbind="$BINDIR/shared/pam_winbind.so"
+service_dir="$SELFTEST_TMPDIR/pam_services"
+service_file="$service_dir/samba"
+
+mkdir $service_dir
+echo "auth        required    $pam_winbind debug debug_state $PAM_OPTIONS" > $service_file
+echo "account     required    $pam_winbind debug debug_state $PAM_OPTIONS" >> $service_file
+echo "password    required    pam_set_items.so" >> $service_file
+echo "password    required    $pam_winbind debug debug_state $PAM_OPTIONS" >> $service_file
+echo "session     required    $pam_winbind debug debug_state $PAM_OPTIONS" >> $service_file
+
+
+PAM_WRAPPER_SERVICE_DIR="$service_dir"
+export PAM_WRAPPER_SERVICE_DIR
+LD_PRELOAD="$LD_PRELOAD:$PAM_WRAPPER_SO_PATH"
+export LD_PRELOAD
+
+PAM_WRAPPER_DEBUGLEVEL=${PAM_WRAPPER_DEBUGLEVEL:="2"}
+export PAM_WRAPPER_DEBUGLEVEL
+
+PAM_WRAPPER="1" PYTHONPATH="$PYTHONPATH:$PAM_WRAPPER_PATH:$(dirname $0)" $PYTHON -m samba.subunit.run samba.tests.pam_winbind_chauthtok
+exit_code=$?
+
+rm -rf $service_dir
+
+if [ "$CREATE_USER" = yes ]; then
+    ./bin/samba-tool user delete "$USERNAME" -H "ldap://$CREATE_SERVER" -U "$CREATE_USERNAME%$CREATE_PASSWORD"
+fi
+
+exit $exit_code

--- a/selftest/tests.py
+++ b/selftest/tests.py
@@ -167,6 +167,15 @@ if with_pam:
                   [os.path.join(srcdir(), "python/samba/tests/test_pam_winbind.sh"),
                    valgrindify(python), pam_wrapper_so_path,
                    "$DOMAIN", "$DC_USERNAME", "$DC_PASSWORD"])
+
+    for pam_options in ["''", "'use_authtok'", "'try_authtok'"]:
+        plantestsuite("samba.tests.pam_winbind_chauthtok with options %s" % pam_options, "ad_member",
+                      [os.path.join(srcdir(), "python/samba/tests/test_pam_winbind_chauthtok.sh"),
+                       valgrindify(python), pam_wrapper_so_path,
+                       "$DOMAIN", "TestPamOptionsUser", "oldp@ssword0", "newp@ssword0",
+                       pam_options, 'yes',
+                       "$DC_SERVER", "$DC_USERNAME", "$DC_PASSWORD"])
+
     plantestsuite("samba.tests.pam_winbind_warn_pwd_expire(domain)", "ad_member",
                   [os.path.join(srcdir(), "python/samba/tests/test_pam_winbind_warn_pwd_expire.sh"),
                    valgrindify(python), pam_wrapper_so_path,

--- a/third_party/pam_wrapper/libpamtest.c
+++ b/third_party/pam_wrapper/libpamtest.c
@@ -214,7 +214,7 @@ static int pamtest_simple_conv(int num_msg,
 			       struct pam_response **response,
 			       void *appdata_ptr)
 {
-	int i, ri = 0;
+	int i = 0;
 	int ret;
 	struct pam_response *reply = NULL;
 	const char *prompt;
@@ -241,15 +241,12 @@ static int pamtest_simple_conv(int num_msg,
 
 			if (reply != NULL) {
 				if (prompt != NULL) {
-					ret = add_to_reply(&reply[ri], prompt);
+					ret = add_to_reply(&reply[i], prompt);
 					if (ret != PAM_SUCCESS) {
 						free_reply(reply, num_msg);
 						return ret;
 					}
-				} else {
-					reply[ri].resp = NULL;
 				}
-				ri++;
 			}
 
 			cctx->echo_off_idx++;
@@ -264,13 +261,12 @@ static int pamtest_simple_conv(int num_msg,
 
 			if (reply != NULL) {
 				if (prompt != NULL) {
-					ret = add_to_reply(&reply[ri], prompt);
+					ret = add_to_reply(&reply[i], prompt);
 					if (ret != PAM_SUCCESS) {
 						free_reply(reply, num_msg);
 						return ret;
 					}
 				}
-				ri++;
 			}
 
 			cctx->echo_on_idx++;
@@ -298,7 +294,7 @@ static int pamtest_simple_conv(int num_msg,
 		}
 	}
 
-	if (response && ri > 0) {
+	if (response) {
 		*response = reply;
 	} else {
 		free(reply);

--- a/third_party/pam_wrapper/modules/pam_set_items.c
+++ b/third_party/pam_wrapper/modules/pam_set_items.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2015 Andreas Schneider <asn@samba.org>
+ * Copyright (c) 2015 Jakub Hrozek <jakub.hrozek@posteo.se>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "config.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef HAVE_SECURITY_PAM_APPL_H
+#include <security/pam_appl.h>
+#endif
+#ifdef HAVE_SECURITY_PAM_MODULES_H
+#include <security/pam_modules.h>
+#endif
+
+#include "config.h"
+
+#define ITEM_FILE_KEY	"item_file="
+
+static const char *envs[] = {
+#ifndef HAVE_OPENPAM
+	"PAM_SERVICE",
+#endif
+	"PAM_USER",
+	"PAM_USER_PROMPT",
+	"PAM_TTY",
+	"PAM_RUSER",
+	"PAM_RHOST",
+	"PAM_AUTHTOK",
+	"PAM_OLDAUTHTOK",
+#ifdef PAM_XDISPLAY
+	"PAM_XDISPLAY",
+#endif
+#ifdef PAM_AUTHTOK_TYPE
+	"PAM_AUTHTOK_TYPE",
+#endif
+	NULL
+};
+
+static const int items[] = {
+#ifndef HAVE_OPENPAM
+	PAM_SERVICE,
+#endif
+	PAM_USER,
+	PAM_USER_PROMPT,
+	PAM_TTY,
+	PAM_RUSER,
+	PAM_RHOST,
+	PAM_AUTHTOK,
+	PAM_OLDAUTHTOK,
+#ifdef PAM_XDISPLAY
+	PAM_XDISPLAY,
+#endif
+#ifdef PAM_AUTHTOK_TYPE
+	PAM_AUTHTOK_TYPE,
+#endif
+};
+
+static void pam_setitem_env(pam_handle_t *pamh)
+{
+	int i;
+	int rv;
+	const char *v;
+
+	for (i = 0; envs[i] != NULL; i++) {
+		v = getenv(envs[i]);
+		if (v == NULL) {
+			continue;
+		}
+
+		rv = pam_set_item(pamh, items[i], v);
+		if (rv != PAM_SUCCESS) {
+			continue;
+		}
+	}
+}
+
+PAM_EXTERN int
+pam_sm_authenticate(pam_handle_t *pamh, int flags,
+		    int argc, const char *argv[])
+{
+	(void) flags;	/* unused */
+	(void) argc;	/* unused */
+	(void) argv;	/* unused */
+
+	pam_setitem_env(pamh);
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_setcred(pam_handle_t *pamh, int flags,
+	       int argc, const char *argv[])
+{
+	(void) flags;	/* unused */
+	(void) argc;	/* unused */
+	(void) argv;	/* unused */
+
+	pam_setitem_env(pamh);
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags,
+		 int argc, const char *argv[])
+{
+	(void) flags;	/* unused */
+	(void) argc;	/* unused */
+	(void) argv;	/* unused */
+
+	pam_setitem_env(pamh);
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_open_session(pam_handle_t *pamh, int flags,
+		    int argc, const char *argv[])
+{
+	(void) flags;	/* unused */
+	(void) argc;	/* unused */
+	(void) argv;	/* unused */
+
+	pam_setitem_env(pamh);
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_close_session(pam_handle_t *pamh, int flags,
+		     int argc, const char *argv[])
+{
+	(void) flags;	/* unused */
+	(void) argc;	/* unused */
+	(void) argv;	/* unused */
+
+	pam_setitem_env(pamh);
+	return PAM_SUCCESS;
+}
+
+PAM_EXTERN int
+pam_sm_chauthtok(pam_handle_t *pamh, int flags,
+		 int argc, const char *argv[])
+{
+	(void) flags;	/* unused */
+	(void) argc;	/* unused */
+	(void) argv;	/* unused */
+
+	pam_setitem_env(pamh);
+	return PAM_SUCCESS;
+}
+

--- a/third_party/pam_wrapper/wscript
+++ b/third_party/pam_wrapper/wscript
@@ -115,6 +115,12 @@ def build(bld):
                             source='libpamtest.c',
                             deps='dl pam')
 
+        bld.SAMBA_LIBRARY('pam_set_items',
+                          source='modules/pam_set_items.c',
+                          deps='pam',
+                          install=False,
+                          realname='pam_set_items.so')
+
         # Can be used to write pam tests in python
         for env in bld.gen_python_environments():
             bld.SAMBA_PYTHON('pypamtest',


### PR DESCRIPTION
Same as the use_authtok option, except that if the new password is not
valid, PAM will prompt for a password.

Bug-Debian: https://bugs.debian.org/858923
Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/samba/+bug/570944

Signed-off-by: Mathieu Parent <math.parent@gmail.com>