### PR TITLE
Python2 python3 compat (in lieu of 'six')

### DIFF
--- a/python/samba/compat.py
+++ b/python/samba/compat.py
@@ -22,8 +22,20 @@ import sys
 PY3 = sys.version_info[0] == 3
 
 if PY3:
+    # compat functions
+    from  urllib.parse import quote as urllib_quote
+    from urllib.request import urlopen as urllib_urlopen
+
+    # compat types
     integer_types = int,
+    string_types = str
     text_type = str
 else:
+    # compat functions
+    from urllib import quote as urllib_quote
+    from urllib import urlopen as urllib_urlopen
+
+    # compat types
     integer_types = (int, long)
+    string_types = basestring
     text_type = unicode

--- a/python/samba/compat.py
+++ b/python/samba/compat.py
@@ -30,6 +30,7 @@ if PY3:
     integer_types = int,
     string_types = str
     text_type = str
+    binary_type = bytes
 
     # alias
     import io
@@ -43,6 +44,7 @@ else:
     integer_types = (int, long)
     string_types = basestring
     text_type = unicode
+    binary_type = str
 
     # alias
     import StringIO

--- a/python/samba/compat.py
+++ b/python/samba/compat.py
@@ -30,6 +30,10 @@ if PY3:
     integer_types = int,
     string_types = str
     text_type = str
+
+    # alias
+    import io
+    StringIO = io.StringIO
 else:
     # compat functions
     from urllib import quote as urllib_quote
@@ -39,3 +43,7 @@ else:
     integer_types = (int, long)
     string_types = basestring
     text_type = unicode
+
+    # alias
+    import StringIO
+    StringIO = StringIO.StringIO


### PR DESCRIPTION
Some updates to samba's own compat.py  to ease writing python2/python3 compatible code