### PR TITLE
More py2 py3 compat

### DIFF
--- a/auth/credentials/tests/bind.py
+++ b/auth/credentials/tests/bind.py
@@ -96,7 +96,7 @@ operatingSystem: Windows Server 2003
 dn: """ + self.computer_dn + """
 changetype: modify
 replace: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"P@ssw0rd\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode(u"\"P@ssw0rd\"".encode('utf-16-le')).decode('utf8') + """
 """)
 
         # do a simple bind and search with the machine account

--- a/lib/ldb/tests/python/api.py
+++ b/lib/ldb/tests/python/api.py
@@ -1957,13 +1957,13 @@ class LdbMsgTests(TestCase):
         self.msg.dn = ldb.Dn(ldb.Ldb(), "@BASEINFO")
         self.msg["foo"] = [b"bla"]
         self.msg["bar"] = [b"bla"]
-        self.assertEqual(["dn", "foo", "bar"], self.msg.keys())
+        self.assertEqual(["dn", "foo", "bar"], list(self.msg.keys()))
 
     def test_keys_text(self):
         self.msg.dn = ldb.Dn(ldb.Ldb(), "@BASEINFO")
         self.msg["foo"] = ["bla"]
         self.msg["bar"] = ["bla"]
-        self.assertEqual(["dn", "foo", "bar"], self.msg.text.keys())
+        self.assertEqual(["dn", "foo", "bar"], list(self.msg.text.keys()))
 
     def test_dn(self):
         self.msg.dn = ldb.Dn(ldb.Ldb(), "@BASEINFO")

--- a/python/samba/domain_update.py
+++ b/python/samba/domain_update.py
@@ -390,7 +390,7 @@ objectClass: msTPM-InformationObjectsContainer
         self.raise_if_not_fix(op)
 
         descriptor = get_managed_service_accounts_descriptor(self.domain_sid)
-        managedservice_descr = b64encode(descriptor)
+        managedservice_descr = b64encode(descriptor).decode('utf8')
         managed_service_dn = "CN=Managed Service Accounts,%s" % \
             str(self.domain_dn)
 

--- a/python/samba/gpclass.py
+++ b/python/samba/gpclass.py
@@ -21,7 +21,7 @@ import tdb
 sys.path.insert(0, "bin/python")
 from samba import NTSTATUSError
 from ConfigParser import ConfigParser
-from StringIO import StringIO
+from samba.compat import StringIO
 from abc import ABCMeta, abstractmethod
 import xml.etree.ElementTree as etree
 import re

--- a/python/samba/idmap.py
+++ b/python/samba/idmap.py
@@ -95,4 +95,4 @@ type: %s
 cn: %s
 
 """ % (sid, unixid, sid, type_string, sid)
-        self.add(self.parse_ldif(mod).next()[1])
+        self.add(next(self.parse_ldif(mod))[1])

--- a/python/samba/join.py
+++ b/python/samba/join.py
@@ -742,7 +742,7 @@ class dc_join(object):
                                                                 {"DNSDOMAIN": ctx.dnsdomain,
                                                                  "DOMAINDN": ctx.base_dn,
                                                                  "HOSTNAME" : ctx.myname,
-                                                                 "DNSPASS_B64": b64encode(ctx.dnspass.encode('utf-16-le')),
+                                                                 "DNSPASS_B64": b64encode(ctx.dnspass.encode('utf-16-le')).decode('utf8'),
                                                                  "DNSNAME" : ctx.dnshostname}))
             for changetype, msg in recs:
                 assert changetype == ldb.CHANGETYPE_NONE

--- a/python/samba/netcmd/__init__.py
+++ b/python/samba/netcmd/__init__.py
@@ -103,7 +103,7 @@ class Command(object):
             force_traceback = True
 
         if isinstance(inner_exception, LdbError):
-            (ldb_ecode, ldb_emsg) = inner_exception
+            (ldb_ecode, ldb_emsg) = inner_exception.args
             self.errf.write("ERROR(ldb): %s - %s\n" % (message, ldb_emsg))
         elif isinstance(inner_exception, AssertionError):
             self.errf.write("ERROR(assert): %s\n" % message)

--- a/python/samba/netcmd/computer.py
+++ b/python/samba/netcmd/computer.py
@@ -298,7 +298,7 @@ Example3 shows how to create a new computer in the OrgUnit organizational unit.
                     samdb, hostname, dns_conn,
                     change_owner_sd, samdb.host_dns_name(),
                     ip_address_list, self.get_logger())
-        except Exception, e:
+        except Exception as e:
             raise CommandError("Failed to create computer '%s': " %
                                computername, e)
 
@@ -394,7 +394,7 @@ sudo is used so a computer may run the command as root.
                 remove_dns_references(
                     samdb, self.get_logger(), computer_dns_host_name,
                     ignore_no_name=True)
-        except Exception, e:
+        except Exception as e:
             raise CommandError('Failed to remove computer "%s"' %
                                samaccountname, e)
         self.outf.write("Deleted computer %s\n" % computername)
@@ -569,7 +569,7 @@ class cmd_computer_move(Command):
         new_computer_dn.add_base(full_new_ou_dn)
         try:
             samdb.rename(computer_dn, new_computer_dn)
-        except Exception, e:
+        except Exception as e:
             raise CommandError('Failed to move computer "%s"' % computername, e)
         self.outf.write('Moved computer "%s" to "%s"\n' %
                         (computername, new_ou_dn))

--- a/python/samba/netcmd/dns.py
+++ b/python/samba/netcmd/dns.py
@@ -140,7 +140,7 @@ def ip4_array_string(array):
     ret = []
     if not array:
         return ret
-    for i in xrange(array.AddrCount):
+    for i in range(array.AddrCount):
         addr = inet_ntop(AF_INET, pack('I', array.AddrArray[i]))
         ret.append(addr)
     return ret
@@ -150,7 +150,7 @@ def dns_addr_array_string(array):
     ret = []
     if not array:
         return ret
-    for i in xrange(array.AddrCount):
+    for i in range(array.AddrCount):
         if array.AddrArray[i].MaxSa[0] == 0x02:
             x = "".join([chr(b) for b in array.AddrArray[i].MaxSa])[4:8]
             addr = inet_ntop(AF_INET, x)
@@ -523,7 +523,7 @@ def dns_record_match(dns_conn, server, zone, name, record_type, data):
         elif record_type == dnsp.DNS_TYPE_TXT:
             if rec.data.count == urec.data.count:
                 found = True
-                for i in xrange(rec.data.count):
+                for i in range(rec.data.count):
                     found = found and \
                             (rec.data.str[i].str == urec.data.str[i].str)
 

--- a/python/samba/netcmd/domain.py
+++ b/python/samba/netcmd/domain.py
@@ -2011,7 +2011,7 @@ class DomainTrustCommand(Command):
         self.outf.write("Namespaces[%d]%s:\n" % (
                         len(fti.entries), tln_string))
 
-        for i in xrange(0, len(fti.entries)):
+        for i in range(0, len(fti.entries)):
             e = fti.entries[i]
 
             flags = e.flags
@@ -3403,7 +3403,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
             for upn in add_upn:
                 idx = None
-                for i in xrange(0, len(update_upn_vals)):
+                for i in range(0, len(update_upn_vals)):
                     v = update_upn_vals[i]
                     if v.lower() != upn.lower():
                         continue
@@ -3416,7 +3416,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
             for upn in delete_upn:
                 idx = None
-                for i in xrange(0, len(update_upn_vals)):
+                for i in range(0, len(update_upn_vals)):
                     v = update_upn_vals[i]
                     if v.lower() != upn.lower():
                         continue
@@ -3430,7 +3430,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
             for spn in add_spn:
                 idx = None
-                for i in xrange(0, len(update_spn_vals)):
+                for i in range(0, len(update_spn_vals)):
                     v = update_spn_vals[i]
                     if v.lower() != spn.lower():
                         continue
@@ -3443,7 +3443,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
             for spn in delete_spn:
                 idx = None
-                for i in xrange(0, len(update_spn_vals)):
+                for i in range(0, len(update_spn_vals)):
                     v = update_spn_vals[i]
                     if v.lower() != spn.lower():
                         continue
@@ -3595,7 +3595,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
         update_forest_info.entries = entries
 
         if enable_all:
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_TOP_LEVEL_NAME:
                     continue
@@ -3603,7 +3603,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
                     continue
                 update_forest_info.entries[i].time = 0
                 update_forest_info.entries[i].flags &= ~lsa.LSA_TLN_DISABLED_MASK
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_DOMAIN_INFO:
                     continue
@@ -3615,7 +3615,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for tln in enable_tln:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_TOP_LEVEL_NAME:
                     continue
@@ -3632,7 +3632,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for tln in disable_tln:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_TOP_LEVEL_NAME:
                     continue
@@ -3650,7 +3650,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for tln_ex in add_tln_ex:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_TOP_LEVEL_NAME_EX:
                     continue
@@ -3663,7 +3663,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
             tln_dot = ".%s" % tln_ex.lower()
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_TOP_LEVEL_NAME:
                     continue
@@ -3692,7 +3692,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for tln_ex in delete_tln_ex:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_TOP_LEVEL_NAME_EX:
                     continue
@@ -3711,7 +3711,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for nb in enable_nb:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_DOMAIN_INFO:
                     continue
@@ -3728,7 +3728,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for nb in disable_nb:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_DOMAIN_INFO:
                     continue
@@ -3746,7 +3746,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for sid in enable_sid:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_DOMAIN_INFO:
                     continue
@@ -3763,7 +3763,7 @@ class cmd_domain_trust_namespaces(DomainTrustCommand):
 
         for sid in disable_sid:
             idx = None
-            for i in xrange(0, len(update_forest_info.entries)):
+            for i in range(0, len(update_forest_info.entries)):
                 r = update_forest_info.entries[i]
                 if r.type != lsa.LSA_FOREST_TRUST_DOMAIN_INFO:
                     continue

--- a/python/samba/netcmd/user.py
+++ b/python/samba/netcmd/user.py
@@ -2027,7 +2027,7 @@ samba-tool user syncpasswords --terminate \\
             if self.lockfd != -1:
                 got_exclusive = False
                 # Try 5 times to get the exclusiv lock.
-                for i in xrange(0, 5):
+                for i in range(0, 5):
                     try:
                         fcntl.lockf(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         got_exclusive = True

--- a/python/samba/netcmd/user.py
+++ b/python/samba/netcmd/user.py
@@ -1879,7 +1879,7 @@ samba-tool user syncpasswords --terminate \\
                 self.current_pid = None
                 self.outf.write("Initialized cache_ldb[%s]\n" % (cache_ldb))
                 msgs = self.cache.parse_ldif(add_ldif)
-                changetype,msg = msgs.next()
+                changetype,msg = next(msgs)
                 ldif = self.cache.write_ldif(msg, ldb.CHANGETYPE_NONE)
                 self.outf.write("%s" % ldif)
             else:

--- a/python/samba/netcmd/user.py
+++ b/python/samba/netcmd/user.py
@@ -119,7 +119,7 @@ def get_crypt_value(alg, utf8pw, rounds=0):
     # we can ignore the possible == at the end
     # of the base64 string
     # we just need to replace '+' by '.'
-    b64salt = base64.b64encode(salt)[0:16].replace('+', '.')
+    b64salt = base64.b64encode(salt)[0:16].replace('+', '.').decode('utf8')
     crypt_salt = ""
     if rounds != 0:
         crypt_salt = "$%s$rounds=%s$%s$" % (alg, rounds, b64salt)
@@ -1247,7 +1247,7 @@ class GetPasswordCommand(Command):
                 h.update(u8)
                 h.update(salt)
                 bv = h.digest() + salt
-                v = "{SSHA}" + base64.b64encode(bv)
+                v = "{SSHA}" + base64.b64encode(bv).decode('utf8')
             elif a == "virtualCryptSHA256":
                 rounds = get_rounds(attr_opts[a])
                 x = get_virtual_crypt_value(a, 5, rounds, username, account_name)
@@ -1861,13 +1861,13 @@ samba-tool user syncpasswords --terminate \\
                 self.sync_command = sync_command
                 add_ldif  = "dn: %s\n" % self.cache_dn
                 add_ldif += "objectClass: userSyncPasswords\n"
-                add_ldif += "samdbUrl:: %s\n" % base64.b64encode(self.samdb_url)
-                add_ldif += "dirsyncFilter:: %s\n" % base64.b64encode(self.dirsync_filter)
+                add_ldif += "samdbUrl:: %s\n" % base64.b64encode(self.samdb_url).decode('utf8')
+                add_ldif += "dirsyncFilter:: %s\n" % base64.b64encode(self.dirsync_filter).decode('utf8')
                 for a in self.dirsync_attrs:
-                    add_ldif += "dirsyncAttribute:: %s\n" % base64.b64encode(a)
+                    add_ldif += "dirsyncAttribute:: %s\n" % base64.b64encode(a).decode('utf8')
                 add_ldif += "dirsyncControl: %s\n" % self.dirsync_controls[0]
                 for a in self.password_attrs:
-                    add_ldif += "passwordAttribute:: %s\n" % base64.b64encode(a)
+                    add_ldif += "passwordAttribute:: %s\n" % base64.b64encode(a).decode('utf8')
                 if self.decrypt_samba_gpg == True:
                     add_ldif += "decryptSambaGPG: TRUE\n"
                 else:

--- a/python/samba/netcmd/visualize.py
+++ b/python/samba/netcmd/visualize.py
@@ -51,7 +51,7 @@ COMMON_OPTIONS = [
            choices=['yes', 'no', 'auto']),
     Option("--color-scheme", help=("use this colour scheme "
                                    "(implies --color=yes)"),
-           choices=COLOUR_SETS.keys()),
+           choices=list(COLOUR_SETS.keys())),
     Option("-S", "--shorten-names",
            help="don't print long common suffixes",
            action='store_true', default=False),

--- a/python/samba/netcmd/visualize.py
+++ b/python/samba/netcmd/visualize.py
@@ -34,6 +34,7 @@ from ldb import SCOPE_BASE, SCOPE_SUBTREE, LdbError
 import time
 from samba.kcc import KCC
 from samba.kcc.kcc_utils import KCCError
+from samba.compat import text_type
 
 COMMON_OPTIONS = [
     Option("-H", "--URL", help="LDB URL for database or target server",
@@ -161,7 +162,10 @@ def colour_hash(x):
     """Generate a randomish but consistent darkish colour based on the
     given object."""
     from hashlib import md5
-    c = int(md5(str(x)).hexdigest()[:6], base=16) & 0x7f7f7f
+    tmp_str = str(x)
+    if isinstance(tmp_str, text_type):
+        tmp_str = tmp_str.encode('utf8')
+    c = int(md5(tmp_str).hexdigest()[:6], base=16) & 0x7f7f7f
     return '#%06x' % c
 
 

--- a/python/samba/provision/__init__.py
+++ b/python/samba/provision/__init__.py
@@ -26,6 +26,7 @@
 
 __docformat__ = "restructuredText"
 
+from samba.compat import urllib_quote
 from base64 import b64encode
 import errno
 import os
@@ -37,7 +38,6 @@ import logging
 import time
 import uuid
 import socket
-import urllib
 import string
 import tempfile
 import samba.dsdb
@@ -2189,7 +2189,7 @@ def provision(logger, session_info, smbconf=None,
     if paths.sysvol and not os.path.exists(paths.sysvol):
         os.makedirs(paths.sysvol, 0o775)
 
-    ldapi_url = "ldapi://%s" % urllib.quote(paths.s4_ldapi_path, safe="")
+    ldapi_url = "ldapi://%s" % urllib_quote(paths.s4_ldapi_path, safe="")
 
     schema = Schema(domainsid, invocationid=invocationid,
         schemadn=names.schemadn, base_schema=base_schema)

--- a/python/samba/provision/__init__.py
+++ b/python/samba/provision/__init__.py
@@ -1020,14 +1020,14 @@ def setup_secretsdb(paths, session_info, backend_credentials, lp):
                 setup_add_ldif(secrets_ldb,
                     setup_path("secrets_simple_ldap.ldif"), {
                         "LDAPMANAGERDN": backend_credentials.get_bind_dn(),
-                        "LDAPMANAGERPASS_B64": b64encode(backend_credentials.get_password())
+                        "LDAPMANAGERPASS_B64": b64encode(backend_credentials.get_password()).decode('utf8')
                         })
             else:
                 setup_add_ldif(secrets_ldb,
                     setup_path("secrets_sasl_ldap.ldif"), {
                         "LDAPADMINUSER": backend_credentials.get_username(),
                         "LDAPADMINREALM": backend_credentials.get_realm(),
-                        "LDAPADMINPASS_B64": b64encode(backend_credentials.get_password())
+                        "LDAPADMINPASS_B64": b64encode(backend_credentials.get_password()).decode('utf8')
                         })
     except:
         secrets_ldb.transaction_cancel()
@@ -1144,7 +1144,7 @@ def setup_self_join(samdb, admin_session_info, names, fill, machinepass,
               "INVOCATIONID": invocationid,
               "NETBIOSNAME": names.netbiosname,
               "DNSNAME": "%s.%s" % (names.hostname, names.dnsdomain),
-              "MACHINEPASS_B64": b64encode(machinepass.encode('utf-16-le')),
+              "MACHINEPASS_B64": b64encode(machinepass.encode('utf-16-le')).decode('utf8'),
               "DOMAINSID": str(domainsid),
               "DCRID": str(dc_rid),
               "SAMBA_VERSION_STRING": version,
@@ -1171,7 +1171,7 @@ def setup_self_join(samdb, admin_session_info, names, fill, machinepass,
                 "INVOCATIONID": invocationid,
                 "NETBIOSNAME": names.netbiosname,
                 "DNSNAME": "%s.%s" % (names.hostname, names.dnsdomain),
-                "MACHINEPASS_B64": b64encode(machinepass.encode('utf-16-le')),
+                "MACHINEPASS_B64": b64encode(machinepass.encode('utf-16-le')).decode('utf8'),
                 "DOMAINSID": str(domainsid),
                 "DCRID": str(dc_rid),
                 "SAMBA_VERSION_STRING": version,
@@ -1208,7 +1208,7 @@ def setup_self_join(samdb, admin_session_info, names, fill, machinepass,
         setup_add_ldif(samdb, setup_path("provision_dns_add_samba.ldif"), {
               "DNSDOMAIN": names.dnsdomain,
               "DOMAINDN": names.domaindn,
-              "DNSPASS_B64": b64encode(dnspass.encode('utf-16-le')),
+              "DNSPASS_B64": b64encode(dnspass.encode('utf-16-le')).decode('utf8'),
               "HOSTNAME" : names.hostname,
               "DNSNAME" : '%s.%s' % (
                   names.netbiosname.lower(), names.dnsdomain.lower())
@@ -1367,7 +1367,7 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
     else:
         domainguid_line = ""
 
-    descr = b64encode(get_domain_descriptor(names.domainsid))
+    descr = b64encode(get_domain_descriptor(names.domainsid)).decode('utf8')
     setup_add_ldif(samdb, setup_path("provision_basedn.ldif"), {
             "DOMAINDN": names.domaindn,
             "DOMAINSID": str(names.domainsid),
@@ -1390,7 +1390,7 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
     # If we are setting up a subdomain, then this has been replicated in, so we don't need to add it
     if fill == FILL_FULL:
         logger.info("Adding configuration container")
-        descr = b64encode(get_config_descriptor(names.domainsid))
+        descr = b64encode(get_config_descriptor(names.domainsid)).decode('utf8')
         setup_add_ldif(samdb, setup_path("provision_configuration_basedn.ldif"), {
                 "CONFIGDN": names.configdn,
                 "DESCRIPTOR": descr,
@@ -1420,12 +1420,12 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
     if fill == FILL_FULL:
         logger.info("Setting up sam.ldb configuration data")
 
-        partitions_descr = b64encode(get_config_partitions_descriptor(names.domainsid))
-        sites_descr = b64encode(get_config_sites_descriptor(names.domainsid))
-        ntdsquotas_descr = b64encode(get_config_ntds_quotas_descriptor(names.domainsid))
-        protected1_descr = b64encode(get_config_delete_protected1_descriptor(names.domainsid))
-        protected1wd_descr = b64encode(get_config_delete_protected1wd_descriptor(names.domainsid))
-        protected2_descr = b64encode(get_config_delete_protected2_descriptor(names.domainsid))
+        partitions_descr = b64encode(get_config_partitions_descriptor(names.domainsid)).decode('utf8')
+        sites_descr = b64encode(get_config_sites_descriptor(names.domainsid)).decode('utf8')
+        ntdsquotas_descr = b64encode(get_config_ntds_quotas_descriptor(names.domainsid)).decode('utf8')
+        protected1_descr = b64encode(get_config_delete_protected1_descriptor(names.domainsid)).decode('utf8')
+        protected1wd_descr = b64encode(get_config_delete_protected1wd_descriptor(names.domainsid)).decode('utf8')
+        protected2_descr = b64encode(get_config_delete_protected2_descriptor(names.domainsid)).decode('utf8')
 
         if "2008" in schema.base_schema:
             # exclude 2012-specific changes if we're using a 2008 schema
@@ -1475,7 +1475,7 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
             })
 
     logger.info("Adding users container")
-    users_desc = b64encode(get_domain_users_descriptor(names.domainsid))
+    users_desc = b64encode(get_domain_users_descriptor(names.domainsid)).decode('utf8')
     setup_add_ldif(samdb, setup_path("provision_users_add.ldif"), {
             "DOMAINDN": names.domaindn,
             "USERS_DESCRIPTOR": users_desc
@@ -1484,7 +1484,7 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
     setup_modify_ldif(samdb, setup_path("provision_users_modify.ldif"), {
             "DOMAINDN": names.domaindn})
     logger.info("Adding computers container")
-    computers_desc = b64encode(get_domain_computers_descriptor(names.domainsid))
+    computers_desc = b64encode(get_domain_computers_descriptor(names.domainsid)).decode('utf8')
     setup_add_ldif(samdb, setup_path("provision_computers_add.ldif"), {
             "DOMAINDN": names.domaindn,
             "COMPUTERS_DESCRIPTOR": computers_desc
@@ -1494,11 +1494,11 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
         setup_path("provision_computers_modify.ldif"), {
             "DOMAINDN": names.domaindn})
     logger.info("Setting up sam.ldb data")
-    infrastructure_desc = b64encode(get_domain_infrastructure_descriptor(names.domainsid))
-    lostandfound_desc = b64encode(get_domain_delete_protected2_descriptor(names.domainsid))
-    system_desc = b64encode(get_domain_delete_protected1_descriptor(names.domainsid))
-    builtin_desc = b64encode(get_domain_builtin_descriptor(names.domainsid))
-    controllers_desc = b64encode(get_domain_controllers_descriptor(names.domainsid))
+    infrastructure_desc = b64encode(get_domain_infrastructure_descriptor(names.domainsid)).decode('utf8')
+    lostandfound_desc = b64encode(get_domain_delete_protected2_descriptor(names.domainsid)).decode('utf8')
+    system_desc = b64encode(get_domain_delete_protected1_descriptor(names.domainsid)).decode('utf8')
+    builtin_desc = b64encode(get_domain_builtin_descriptor(names.domainsid)).decode('utf8')
+    controllers_desc = b64encode(get_domain_controllers_descriptor(names.domainsid)).decode('utf8')
     setup_add_ldif(samdb, setup_path("provision.ldif"), {
         "CREATTIME": str(samba.unix2nttime(int(time.time()))),
         "DOMAINDN": names.domaindn,
@@ -1517,14 +1517,14 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
 
     # If we are setting up a subdomain, then this has been replicated in, so we don't need to add it
     if fill == FILL_FULL:
-        managedservice_descr = b64encode(get_managed_service_accounts_descriptor(names.domainsid))
+        managedservice_descr = b64encode(get_managed_service_accounts_descriptor(names.domainsid)).decode('utf8')
         setup_modify_ldif(samdb,
                           setup_path("provision_configuration_references.ldif"), {
                 "CONFIGDN": names.configdn,
                 "SCHEMADN": names.schemadn})
 
         logger.info("Setting up well known security principals")
-        protected1wd_descr = b64encode(get_config_delete_protected1wd_descriptor(names.domainsid))
+        protected1wd_descr = b64encode(get_config_delete_protected1wd_descriptor(names.domainsid)).decode('utf8')
         setup_add_ldif(samdb, setup_path("provision_well_known_sec_princ.ldif"), {
             "CONFIGDN": names.configdn,
             "WELLKNOWNPRINCIPALS_DESCRIPTOR": protected1wd_descr,
@@ -1541,8 +1541,8 @@ def fill_samdb(samdb, lp, names, logger, policyguid,
         setup_add_ldif(samdb, setup_path("provision_users.ldif"), {
             "DOMAINDN": names.domaindn,
             "DOMAINSID": str(names.domainsid),
-            "ADMINPASS_B64": b64encode(adminpass.encode('utf-16-le')),
-            "KRBTGTPASS_B64": b64encode(krbtgtpass.encode('utf-16-le'))
+            "ADMINPASS_B64": b64encode(adminpass.encode('utf-16-le')).decode('utf8'),
+            "KRBTGTPASS_B64": b64encode(krbtgtpass.encode('utf-16-le')).decode('utf8')
             }, controls=["relax:0", "provision:0"])
 
         logger.info("Setting up self join")

--- a/python/samba/provision/backend.py
+++ b/python/samba/provision/backend.py
@@ -25,6 +25,7 @@
 
 """Functions for setting up a Samba configuration (LDB and LDAP backends)."""
 
+from samba.compat import urllib_quote
 from base64 import b64encode
 import errno
 import ldb
@@ -183,7 +184,7 @@ class LDAPBackend(ProvisionBackend):
         if ldap_backend_forced_uri is not None:
             self.ldap_uri = ldap_backend_forced_uri
         else:
-            self.ldap_uri = "ldapi://%s" % urllib.quote(
+            self.ldap_uri = "ldapi://%s" % urllib_quote(
                 os.path.join(self.ldapdir, "ldapi"), safe="")
 
         if not os.path.exists(self.ldapdir):

--- a/python/samba/provision/sambadns.py
+++ b/python/samba/provision/sambadns.py
@@ -247,12 +247,12 @@ def setup_dns_partitions(samdb, domainsid, domaindn, forestdn, configdn,
 
     setup_add_ldif(samdb, setup_path("provision_dnszones_partitions.ldif"), {
         "ZONE_DN": domainzone_dn,
-        "SECDESC"      : b64encode(descriptor)
+        "SECDESC"      : b64encode(descriptor).decode('utf8')
         })
     if fill_level != FILL_SUBDOMAIN:
         setup_add_ldif(samdb, setup_path("provision_dnszones_partitions.ldif"), {
             "ZONE_DN": forestzone_dn,
-            "SECDESC"      : b64encode(descriptor)
+            "SECDESC"      : b64encode(descriptor).decode('utf8')
         })
 
     domainzone_guid = get_domainguid(samdb, domainzone_dn)
@@ -267,8 +267,8 @@ def setup_dns_partitions(samdb, domainsid, domaindn, forestdn, configdn,
         "ZONE_DNS": domainzone_dns,
         "CONFIGDN": configdn,
         "SERVERDN": serverdn,
-        "LOSTANDFOUND_DESCRIPTOR": b64encode(protected2_desc),
-        "INFRASTRUCTURE_DESCRIPTOR": b64encode(protected1_desc),
+        "LOSTANDFOUND_DESCRIPTOR": b64encode(protected2_desc).decode('utf8'),
+        "INFRASTRUCTURE_DESCRIPTOR": b64encode(protected1_desc).decode('utf8'),
         })
     setup_modify_ldif(samdb, setup_path("provision_dnszones_modify.ldif"), {
         "CONFIGDN": configdn,
@@ -287,8 +287,8 @@ def setup_dns_partitions(samdb, domainsid, domaindn, forestdn, configdn,
             "ZONE_DNS": forestzone_dns,
             "CONFIGDN": configdn,
             "SERVERDN": serverdn,
-            "LOSTANDFOUND_DESCRIPTOR": b64encode(protected2_desc),
-            "INFRASTRUCTURE_DESCRIPTOR": b64encode(protected1_desc),
+            "LOSTANDFOUND_DESCRIPTOR": b64encode(protected2_desc).decode('utf8'),
+            "INFRASTRUCTURE_DESCRIPTOR": b64encode(protected1_desc).decode('utf8'),
         })
         setup_modify_ldif(samdb, setup_path("provision_dnszones_modify.ldif"), {
             "CONFIGDN": configdn,
@@ -675,7 +675,7 @@ def secretsdb_setup_dns(secretsdb, names, private_dir, binddns_dir, realm,
             "REALM": realm,
             "DNSDOMAIN": dnsdomain,
             "DNS_KEYTAB": dns_keytab_path,
-            "DNSPASS_B64": b64encode(dnspass.encode('utf-8')),
+            "DNSPASS_B64": b64encode(dnspass.encode('utf-8')).decode('utf8'),
             "KEY_VERSION_NUMBER": str(key_version_number),
             "HOSTNAME": names.hostname,
             "DNSNAME" : '%s.%s' % (
@@ -817,7 +817,7 @@ def create_samdb_copy(samdb, logger, paths, names, domainsid, domainguid):
         dom_ldb.add(index_res[0])
 
         domainguid_line = "objectGUID: %s\n-" % domainguid
-        descr = b64encode(get_domain_descriptor(domainsid))
+        descr = b64encode(get_domain_descriptor(domainsid)).decode('utf8')
         setup_add_ldif(dom_ldb, setup_path("provision_basedn.ldif"), {
             "DOMAINDN" : names.domaindn,
             "DOMAINGUID" : domainguid_line,

--- a/python/samba/schema.py
+++ b/python/samba/schema.py
@@ -122,7 +122,7 @@ class Schema(object):
             setup_path("provision_schema_basedn_modify.ldif"),
             {"SCHEMADN": schemadn, "OBJVERSION" : schema_version})
 
-        descr = b64encode(get_schema_descriptor(domain_sid))
+        descr = b64encode(get_schema_descriptor(domain_sid)).decode('utf8')
         self.schema_dn_add = read_and_sub_file(
             setup_path("provision_schema_basedn.ldif"),
             {"SCHEMADN": schemadn, "DESCRIPTOR": descr})
@@ -136,7 +136,7 @@ class Schema(object):
             for map in additional_prefixmap:
                 self.prefixmap_data += "%s\n" % map
 
-        self.prefixmap_data = b64encode(self.prefixmap_data)
+        self.prefixmap_data = b64encode(self.prefixmap_data).decode('utf8')
 
         # We don't actually add this ldif, just parse it
         prefixmap_ldif = "dn: %s\nprefixMap:: %s\n\n" % (self.schemadn, self.prefixmap_data)

--- a/python/samba/tests/blackbox/samba_dnsupdate.py
+++ b/python/samba/tests/blackbox/samba_dnsupdate.py
@@ -17,7 +17,7 @@
 #
 
 import samba.tests
-from StringIO import StringIO
+from samba.compat import StringIO
 from samba.netcmd.main import cmd_sambatool
 from samba.credentials import Credentials
 from samba.auth import system_session

--- a/python/samba/tests/dcerpc/dnsserver.py
+++ b/python/samba/tests/dcerpc/dnsserver.py
@@ -39,7 +39,7 @@ class DnsserverTests(RpcInterfaceTestCase):
                     "EXAMPLE",
                     "\n.COM",
                     "!@#$%^&*()_",
-                    "HIGH\xFFBYTE",
+                    u"HIGH\xFFBYTE",
                     "@.EXAMPLE.COM",
                     "."]
         bad_dns = ["...",

--- a/python/samba/tests/dns_forwarder.py
+++ b/python/samba/tests/dns_forwarder.py
@@ -186,7 +186,7 @@ class TestDnsForwarding(DNSTest):
                              host, str(port), id])
         self.subprocesses.append(p)
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
-        for i in xrange(300):
+        for i in range(300):
             time.sleep(0.05)
             s.connect((host, port))
             try:

--- a/python/samba/tests/emulate/traffic.py
+++ b/python/samba/tests/emulate/traffic.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # from pprint import pprint
-from cStringIO import StringIO
+from samba.compat import StringIO
 
 import samba.tests
 

--- a/python/samba/tests/netcmd.py
+++ b/python/samba/tests/netcmd.py
@@ -17,7 +17,7 @@
 
 """Tests for samba.netcmd."""
 
-from cStringIO import StringIO
+from samba.compat import StringIO
 from samba.netcmd import Command
 from samba.netcmd.testparm import cmd_testparm
 from samba.netcmd.main import cmd_sambatool

--- a/python/samba/tests/password_hash.py
+++ b/python/samba/tests/password_hash.py
@@ -34,6 +34,7 @@ import samba
 import binascii
 from hashlib import md5
 import crypt
+from samba.compat import text_type
 
 
 USER_NAME = "PasswordHashTestUser"
@@ -60,6 +61,9 @@ def get_package(sc, name):
 def calc_digest(user, realm, password):
 
     data = "%s:%s:%s" % (user, realm, password)
+    if isinstance(data, text_type):
+        data = data.encode('utf8')
+
     return md5(data).hexdigest()
 
 

--- a/python/samba/tests/samba_tool/base.py
+++ b/python/samba/tests/samba_tool/base.py
@@ -25,7 +25,7 @@ import random
 import string
 from samba.auth import system_session
 from samba.samdb import SamDB
-from cStringIO import StringIO
+from samba.compat import StringIO
 from samba.netcmd.main import cmd_sambatool
 import samba.tests
 

--- a/python/samba/tests/samba_tool/dnscmd.py
+++ b/python/samba/tests/samba_tool/dnscmd.py
@@ -48,7 +48,7 @@ class DnsCmdTestCase(SambaToolCmdTest):
                     "EXAMPLE",
                     "\n.COM",
                     "!@#$%^&*()_",
-                    "HIGH\xFFBYTE",
+                    u"HIGH\xFFBYTE",
                     "@.EXAMPLE.COM",
                     "."]
         bad_dns = ["...",

--- a/python/samba/tests/samba_tool/user.py
+++ b/python/samba/tests/samba_tool/user.py
@@ -121,7 +121,7 @@ class UserCmdTestCase(SambaToolCmdTest):
             return
 
         def find_package(packages, name, start_idx=0):
-            for i in xrange(start_idx, len(packages)):
+            for i in range(start_idx, len(packages)):
                 if packages[i].name == name:
                     return (i, packages[i])
             return (None, None)

--- a/python/samba/tests/samba_tool/user.py
+++ b/python/samba/tests/samba_tool/user.py
@@ -234,9 +234,9 @@ class UserCmdTestCase(SambaToolCmdTest):
             creds.set_anonymous()
             creds.set_password(newpasswd)
             nthash = creds.get_nt_hash()
-            unicodePwd = base64.b64encode(creds.get_nt_hash())
-            virtualClearTextUTF8 = base64.b64encode(newpasswd)
-            virtualClearTextUTF16 = base64.b64encode(unicode(newpasswd, 'utf-8').encode('utf-16-le'))
+            unicodePwd = base64.b64encode(creds.get_nt_hash()).decode('utf8')
+            virtualClearTextUTF8 = base64.b64encode(newpasswd).decode('utf8')
+            virtualClearTextUTF16 = base64.b64encode(unicode(newpasswd, 'utf-8').encode('utf-16-le')).decode('utf8')
 
             (result, out, err) = self.runsubcmd("user", "setpassword",
                                                 user["name"],

--- a/python/samba/tests/samba_tool/user_wdigest.py
+++ b/python/samba/tests/samba_tool/user_wdigest.py
@@ -33,6 +33,7 @@ from samba.dcerpc import drsblobs
 from hashlib import md5
 import random
 import string
+from samba.compat import text_type
 
 USER_NAME = "WdigestTestUser"
 # Create a random 32 character password, containing only letters and
@@ -45,6 +46,9 @@ USER_PASS = ''.join(random.choice(string.ascii_uppercase +
 #
 def calc_digest(user, realm, password):
     data = "%s:%s:%s" % (user, realm, password)
+    if isinstance(data, text_type):
+        data = data.encode('utf8')
+
     return "%s:%s:%s" % (user, realm, md5(data).hexdigest())
 
 

--- a/source4/dsdb/tests/python/acl.py
+++ b/source4/dsdb/tests/python/acl.py
@@ -951,14 +951,14 @@ class AclSearchTests(AclTests):
                                     scope=SCOPE_SUBTREE)
         ok_list = ['dn']
         self.assertEquals(len(res), 1)
-        res_list = res[0].keys()
+        res_list = list(res[0].keys())
         self.assertEquals(res_list, ok_list)
 
         res = self.ldb_user.search("OU=ou2,OU=ou1," + self.base_dn, expression="(objectClass=*)",
                                     scope=SCOPE_BASE, attrs=["ou"])
 
         self.assertEquals(len(res), 1)
-        res_list = res[0].keys()
+        res_list = list(res[0].keys())
         self.assertEquals(res_list, ok_list)
 
         #give read property on ou and assert user can only see dn and ou
@@ -969,7 +969,7 @@ class AclSearchTests(AclTests):
                                     scope=SCOPE_SUBTREE)
         ok_list = ['dn', 'ou']
         self.assertEquals(len(res), 1)
-        res_list = res[0].keys()
+        res_list = list(res[0].keys())
         self.assertEquals(sorted(res_list), sorted(ok_list))
 
         #give read property on Public Information and assert user can see ou and other members
@@ -980,7 +980,7 @@ class AclSearchTests(AclTests):
                                     scope=SCOPE_SUBTREE)
 
         ok_list = ['dn', 'objectClass', 'ou', 'distinguishedName', 'name', 'objectGUID', 'objectCategory']
-        res_list = res[0].keys()
+        res_list = list(res[0].keys())
         self.assertEquals(sorted(res_list), sorted(ok_list))
 
     def test_search6(self):
@@ -1005,7 +1005,7 @@ class AclSearchTests(AclTests):
                                     scope=SCOPE_SUBTREE)
         self.assertEquals(len(res), 1)
         ok_list = ['dn', 'ou']
-        res_list = res[0].keys()
+        res_list = list(res[0].keys())
         self.assertEquals(sorted(res_list), sorted(ok_list))
 
         #give read property on Public Information and assert user can see ou and other members
@@ -1015,7 +1015,7 @@ class AclSearchTests(AclTests):
                                    scope=SCOPE_SUBTREE)
         self.assertEquals(len(res), 1)
         ok_list = ['dn', 'objectClass', 'ou', 'distinguishedName', 'name', 'objectGUID', 'objectCategory']
-        res_list = res[0].keys()
+        res_list = list(res[0].keys())
         self.assertEquals(sorted(res_list), sorted(ok_list))
 
 #tests on ldap delete operations

--- a/source4/dsdb/tests/python/acl.py
+++ b/source4/dsdb/tests/python/acl.py
@@ -1383,9 +1383,9 @@ class AclCARTests(AclTests):
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 """)
         except LdbError as e24:
             (num, _) = e24.args
@@ -1410,9 +1410,9 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) 
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 """)
         except LdbError as e25:
             (num, _) = e25.args
@@ -1431,9 +1431,9 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) 
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 """)
 
     def test_change_password5(self):
@@ -1511,18 +1511,18 @@ userPassword: thatsAcomplPASS2
 dn: """ + self.get_user_dn(self.user_with_pc) + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')).decode('utf8') + """
 """)
         #then someone else's
         self.ldb_user2.modify_ldif("""
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"samba123@\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 """)
 
     def test_reset_password1(self):
@@ -1532,7 +1532,7 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) 
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 replace: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')).decode('utf8') + """
 """)
         except LdbError as e29:
             (num, _) = e29.args
@@ -1545,7 +1545,7 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) 
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 replace: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')).decode('utf8') + """
 """)
 
     def test_reset_password2(self):
@@ -1585,7 +1585,7 @@ userPassword: thatsAcomplPASS1
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 replace: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')).decode('utf8') + """
 """)
         except LdbError as e32:
             (num, _) = e32.args
@@ -1618,7 +1618,7 @@ userPassword: thatsAcomplPASS1
 dn: """ + self.get_user_dn(self.user_with_wp) + """
 changetype: modify
 replace: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')).decode('utf8') + """
 """)
 
     def test_reset_password6(self):

--- a/source4/dsdb/tests/python/dirsync.py
+++ b/source4/dsdb/tests/python/dirsync.py
@@ -582,7 +582,7 @@ class SimpleDirsyncTests(DirsyncBaseTests):
         ctl = str(res.controls[0]).split(":")
         cookie = ndr_unpack(drsblobs.ldapControlDirSyncCookie, base64.b64decode(str(ctl[4])))
         cookie.blob.guid1 = misc.GUID("128a99bf-abcd-1234-abcd-1fb625e530db")
-        controls=["dirsync:1:0:0:%s" % base64.b64encode(ndr_pack(cookie))]
+        controls=["dirsync:1:0:0:%s" % base64.b64encode(ndr_pack(cookie)).decode('utf8')]
         res = self.ldb_admin.search(self.base_dn,
                                     expression="(&(objectClass=organizationalUnit)(!(isDeleted=*)))",
                                     controls=controls)

--- a/source4/dsdb/tests/python/ldap.py
+++ b/source4/dsdb/tests/python/ldap.py
@@ -2853,7 +2853,7 @@ nTSecurityDescriptor: """ + sddl)
             sddl = "O:DUG:DUD:PAI(A;;RPWP;;;AU)S:PAI"
             desc = security.descriptor.from_sddl(sddl, self.domain_sid)
             desc_binary = ndr_pack(desc)
-            desc_base64 = base64.b64encode(desc_binary)
+            desc_base64 = base64.b64encode(desc_binary).decode('utf8')
             self.ldb.add_ldif("""
 dn: """ + user_dn + """
 objectclass: user
@@ -2877,7 +2877,7 @@ nTSecurityDescriptor:: """ + desc_base64)
         try:
             sddl = "O:DUG:DUD:AI(A;;RPWP;;;AU)S:PAI"
             desc = security.descriptor.from_sddl(sddl, security.dom_sid('S-1-5-21'))
-            desc_base64 = base64.b64encode( ndr_pack(desc) )
+            desc_base64 = base64.b64encode( ndr_pack(desc) ).decode('utf8')
             self.ldb.add_ldif("""
 dn: """ + user_dn + """
 objectclass: user
@@ -3008,7 +3008,7 @@ sAMAccountName: """ + user_name)
             desc_sddl = desc.as_sddl(self.domain_sid)
             sddl = desc_sddl[:desc_sddl.find("(")] + "(A;;RPWP;;;AU)" + desc_sddl[desc_sddl.find("("):]
             desc = security.descriptor.from_sddl(sddl, self.domain_sid)
-            desc_base64 = base64.b64encode(ndr_pack(desc))
+            desc_base64 = base64.b64encode(ndr_pack(desc)).decode('utf8')
             mod = """
 dn: """ + user_dn + """
 changetype: modify
@@ -3036,7 +3036,7 @@ sAMAccountName: """ + user_name)
             # Modify descriptor
             sddl = "O:DUG:DUD:PAI(A;;RPWP;;;AU)S:PAI"
             desc = security.descriptor.from_sddl(sddl, self.domain_sid)
-            desc_base64 = base64.b64encode(ndr_pack(desc))
+            desc_base64 = base64.b64encode(ndr_pack(desc)).decode('utf8')
             mod = """
 dn: """ + user_dn + """
 changetype: modify

--- a/source4/dsdb/tests/python/notification.py
+++ b/source4/dsdb/tests/python/notification.py
@@ -163,7 +163,7 @@ delete: otherLoginWorkstations
         max_notifications = 5
 
         notifies = [None] * (max_notifications + 1)
-        for i in xrange(0, max_notifications + 1):
+        for i in range(0, max_notifications + 1):
             notifies[i] = self.ldb.search_iterator(base=self.base_dn,
                                                    expression="(objectClass=*)",
                                                    scope=ldb.SCOPE_SUBTREE,
@@ -172,7 +172,7 @@ delete: otherLoginWorkstations
                                                    timeout=1)
         num_admin_limit = 0
         num_time_limit = 0
-        for i in xrange(0, max_notifications + 1):
+        for i in range(0, max_notifications + 1):
             try:
                 for msg in notifies[i]:
                     continue

--- a/source4/dsdb/tests/python/password_lockout.py
+++ b/source4/dsdb/tests/python/password_lockout.py
@@ -418,9 +418,9 @@ userPassword: thatsAcomplPASS2x
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2x\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2x\"".encode('utf-16-le')).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e7:
@@ -459,9 +459,9 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2x\"".encode('utf-16-le'))
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2x\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2x\"".encode('utf-16-le')).decode('utf8') + """
 """)
         userpass = "thatsAcomplPASS2x"
         creds.set_password(userpass)
@@ -614,9 +614,9 @@ userPassword: thatsAcomplPASS2XYZ
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1x\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1x\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e10:
@@ -646,9 +646,9 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) 
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(old_utf16) + """
+unicodePwd:: """ + base64.b64encode(old_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
 
         res = self._check_account(userdn,
@@ -667,9 +667,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(old_utf16) + """
+unicodePwd:: """ + base64.b64encode(old_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e11:
@@ -711,9 +711,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
+unicodePwd:: """ + base64.b64encode(invalid_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e12:
@@ -741,9 +741,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
+unicodePwd:: """ + base64.b64encode(invalid_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e13:
@@ -768,9 +768,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
+unicodePwd:: """ + base64.b64encode(invalid_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e14:
@@ -795,9 +795,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
+unicodePwd:: """ + base64.b64encode(invalid_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e15:
@@ -841,9 +841,9 @@ unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(old_utf16) + """
+unicodePwd:: """ + base64.b64encode(old_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
 
         res = self._check_account(userdn,
@@ -863,9 +863,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
+unicodePwd:: """ + base64.b64encode(invalid_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e16:
@@ -891,9 +891,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
+unicodePwd:: """ + base64.b64encode(invalid_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e17:
@@ -934,9 +934,9 @@ unicodePwd:: """ + base64.b64encode(new_utf16) + """
 dn: """ + userdn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode(invalid_utf16) + """
+unicodePwd:: """ + base64.b64encode(invalid_utf16).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode(new_utf16) + """
+unicodePwd:: """ + base64.b64encode(new_utf16).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e18:

--- a/source4/dsdb/tests/python/passwords.py
+++ b/source4/dsdb/tests/python/passwords.py
@@ -213,9 +213,9 @@ unicodePwd: YYYYYYYYYYYYYYYY
 dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS1\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 """)
 
         # Wrong old password
@@ -224,9 +224,9 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) 
 dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS4\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS4\"".encode('utf-16-le')).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e4:
@@ -240,9 +240,9 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS4\"".encode('utf-16-le')) 
 dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS2\"".encode('utf-16-le')).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e5:
@@ -366,9 +366,9 @@ userPassword: thatsAcomplPASS2
 dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: clearTextPassword
-clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS1".encode('utf-16-le')) + """
+clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS1".encode('utf-16-le')).decode('utf8') + """
 add: clearTextPassword
-clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')) + """
+clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')).decode('utf8') + """
 """)
             # this passes against s4
         except LdbError as e11:
@@ -383,9 +383,9 @@ clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le'
 dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: clearTextPassword
-clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS3".encode('utf-16-le')) + """
+clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS3".encode('utf-16-le')).decode('utf8') + """
 add: clearTextPassword
-clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS4".encode('utf-16-le')) + """
+clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS4".encode('utf-16-le')).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e12:
@@ -401,9 +401,9 @@ clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS4".encode('utf-16-le'
 dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: clearTextPassword
-clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')) + """
+clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')).decode('utf8') + """
 add: clearTextPassword
-clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')) + """
+clearTextPassword:: """ + base64.b64encode("thatsAcomplPASS2".encode('utf-16-le')).decode('utf8') + """
 """)
             self.fail()
         except LdbError as e13:
@@ -659,7 +659,7 @@ changetype: modify
 delete: userPassword
 userPassword: thatsAcomplPASS2
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')).decode('utf8') + """
 """)
              # this passes against s4
         except LdbError as e30:
@@ -671,7 +671,7 @@ unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')) 
 dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')).decode('utf8') + """
 add: userPassword
 userPassword: thatsAcomplPASS4
 """)
@@ -1130,7 +1130,7 @@ dn: cn=testuser,cn=users,""" + self.base_dn + """
 changetype: modify
 delete: unicodePwd
 add: unicodePwd
-unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode("\"thatsAcomplPASS3\"".encode('utf-16-le')).decode('utf8') + """
 """)
         except LdbError, (num, msg):
             self.assertEquals(num, ERR_CONSTRAINT_VIOLATION)

--- a/source4/dsdb/tests/python/rodc_rwdc.py
+++ b/source4/dsdb/tests/python/rodc_rwdc.py
@@ -31,7 +31,7 @@ from samba.dcerpc import security, samr
 import password_lockout_base
 
 def passwd_encode(pw):
-    return base64.b64encode(('"%s"' % pw).encode('utf-16-le'))
+    return base64.b64encode(('"%s"' % pw).encode('utf-16-le')).decode('utf8')
 
 
 class RodcRwdcTestException(Exception):

--- a/source4/dsdb/tests/python/sam.py
+++ b/source4/dsdb/tests/python/sam.py
@@ -2536,7 +2536,7 @@ class SamTests(samba.tests.TestCase):
         delete_force(self.ldb, "cn=ldaptestcomputer,cn=computers," + self.base_dn)
 
     def find_repl_meta_data(self, rpmd, attid):
-        for i in xrange(0, rpmd.ctr.count):
+        for i in range(0, rpmd.ctr.count):
             m = rpmd.ctr.array[i]
             if m.attid == attid:
                 return m

--- a/source4/dsdb/tests/python/sec_descriptor.py
+++ b/source4/dsdb/tests/python/sec_descriptor.py
@@ -96,7 +96,7 @@ systemOnly: FALSE
             if isinstance(desc, str):
                 ldif += "nTSecurityDescriptor: %s" % desc
             elif isinstance(desc, security.descriptor):
-                ldif += "nTSecurityDescriptor:: %s" % base64.b64encode(ndr_pack(desc))
+                ldif += "nTSecurityDescriptor:: %s" % base64.b64encode(ndr_pack(desc)).decode('utf8')
         _ldb.add_ldif(ldif)
         return class_dn
 
@@ -113,7 +113,7 @@ instanceType: 4
             if isinstance(desc, str):
                 ldif += "nTSecurityDescriptor: %s" % desc
             elif isinstance(desc, security.descriptor):
-                ldif += "nTSecurityDescriptor:: %s" % base64.b64encode(ndr_pack(desc))
+                ldif += "nTSecurityDescriptor:: %s" % base64.b64encode(ndr_pack(desc)).decode('utf8')
         _ldb.add_ldif(ldif)
 
     def create_configuration_specifier(self, _ldb, object_dn, desc=None):
@@ -127,7 +127,7 @@ showInAdvancedViewOnly: TRUE
             if isinstance(desc, str):
                 ldif += "nTSecurityDescriptor: %s" % desc
             elif isinstance(desc, security.descriptor):
-                ldif += "nTSecurityDescriptor:: %s" % base64.b64encode(ndr_pack(desc))
+                ldif += "nTSecurityDescriptor:: %s" % base64.b64encode(ndr_pack(desc)).decode('utf8')
         _ldb.add_ldif(ldif)
 
     def get_ldb_connection(self, target_username, target_password):

--- a/source4/dsdb/tests/python/vlv.py
+++ b/source4/dsdb/tests/python/vlv.py
@@ -69,7 +69,7 @@ def encode_vlv_control(critical=1,
     if offset is not None:
         m = "%d:%d" % (offset, n)
     elif ':' in gte or '\x00' in gte:
-        gte = base64.b64encode(gte)
+        gte = base64.b64encode(gte).decode('utf8')
         m = "base64>=%s" % gte
     else:
         m = ">=%s" % gte

--- a/source4/heimdal/lib/wind/gen-normalize.py
+++ b/source4/heimdal/lib/wind/gen-normalize.py
@@ -51,7 +51,7 @@ ud = UnicodeData.read(sys.argv[1])
 
 def sortedKeys(d):
     """Return a sorted list of the keys of a dict"""
-    keys = d.keys()
+    keys = list(d.keys())
     keys.sort()
     return keys
 

--- a/source4/scripting/bin/fullschema
+++ b/source4/scripting/bin/fullschema
@@ -147,7 +147,7 @@ def write_ldif_one(o, attrs):
             value = fix_dn(j)
             if a != "cn":
                 if a == "oMObjectClass":
-                    print "%s:: %s" % (a, base64.b64encode(value))
+                    print "%s:: %s" % (a, base64.b64encode(value)).decode('utf8')
                 elif a.endswith("GUID"):
                     print "%s: %s" % (a, ldb.schema_format_value(a, value))
                 else:

--- a/source4/scripting/bin/get-descriptors
+++ b/source4/scripting/bin/get-descriptors
@@ -85,7 +85,7 @@ class DescrGetter:
         ldif_entry = ["dn: " + dn,
                       "changetype: modify",
                       "replace: nTSecurityDescriptor",
-                      "nTSecurityDescriptor::  " + base64.b64encode(ndr_pack(descr))]
+                      "nTSecurityDescriptor::  " + base64.b64encode(ndr_pack(descr)).decode('utf8')]
 
         for line in ldif_entry:
             length = 79

--- a/source4/scripting/bin/minschema
+++ b/source4/scripting/bin/minschema
@@ -200,7 +200,7 @@ def write_ldif_one(o, attrs):
         for j in v:
 			value = fix_dn(j)
 			if a == "oMObjectClass":
-				print "%s:: %s" % (a, base64.b64encode(value))
+				print "%s:: %s" % (a, base64.b64encode(value).decode('utf8'))
 			elif a.endswith("GUID"):
 				print "%s: %s" % (a, ldb.schema_format_value(a, value))
 			else:

--- a/source4/scripting/bin/samba_upgradedns
+++ b/source4/scripting/bin/samba_upgradedns
@@ -469,7 +469,7 @@ if __name__ == '__main__':
             setup_add_ldif(ldbs.sam, setup_path("provision_dns_add_samba.ldif"), {
                     "DNSDOMAIN": dnsdomain,
                     "DOMAINDN": domaindn,
-                    "DNSPASS_B64": b64encode(dnspass.encode('utf-16-le')),
+                    "DNSPASS_B64": b64encode(dnspass.encode('utf-16-le')).decode('utf8'),
                     "HOSTNAME" : hostname,
                     "DNSNAME" : dnsname }
                            )

--- a/source4/scripting/bin/samba_upgradeprovision
+++ b/source4/scripting/bin/samba_upgradeprovision
@@ -1067,7 +1067,7 @@ def reload_full_schema(samdb, names):
         schema_ldif += samdb.write_ldif(ent, ldb.CHANGETYPE_NONE)
 
     prefixmap_data = open(setup_path("prefixMap.txt"), 'r').read()
-    prefixmap_data = b64encode(prefixmap_data)
+    prefixmap_data = b64encode(prefixmap_data).decode('utf8')
 
     # We don't actually add this ldif, just parse it
     prefixmap_ldif = "dn: %s\nprefixMap:: %s\n\n" % (schemadn, prefixmap_data)

--- a/source4/scripting/bin/smbstatus
+++ b/source4/scripting/bin/smbstatus
@@ -26,7 +26,7 @@ from samba import irpc, messaging
 def show_sessions(conn):
     """show open sessions"""
 
-    sessions = conn.smbsrv_information(irpc.SMBSRV_INFO_SESSIONS).next()
+    sessions = next(conn.smbsrv_information(irpc.SMBSRV_INFO_SESSIONS))
     print "User                                  Client      Connected at"
     print "-" * 79
     for session in sessions:
@@ -37,7 +37,7 @@ def show_sessions(conn):
 def show_tcons(open_connection):
     """show open tree connects"""
     conn = open_connection("smb_server")
-    tcons = conn.smbsrv_information(irpc.SMBSRV_INFO_TCONS).next()
+    tcons = next(conn.smbsrv_information(irpc.SMBSRV_INFO_TCONS))
     print "Share                                 Client      Connected at"
     print "-" * 79
     for tcon in tcons:
@@ -47,7 +47,7 @@ def show_tcons(open_connection):
 def show_nbt(open_connection):
     """show nbtd information"""
     conn = open_connection("nbt_server")
-    stats = conn.nbtd_information(irpc.NBTD_INFO_STATISTICS).next()
+    stats = next(conn.nbtd_information(irpc.NBTD_INFO_STATISTICS))
     print "NBT server statistics:"
     fields = [("total_received", "Total received"),
               ("total_sent", "Total sent"),

--- a/source4/scripting/devel/demodirsync.py
+++ b/source4/scripting/devel/demodirsync.py
@@ -74,7 +74,7 @@ savedcookie = cookie
 
 print("")
 print("Getting allusers with cookie")
-controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie))]
+controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie)).decode('utf8')]
 (msgs, ctrls) = remote_ldb.searchex(expression="(samaccountname=*)", base=base, attrs=["objectClass"], controls=controls)
 if (len(ctrls)):
     for ctl in ctrls:
@@ -88,7 +88,7 @@ if cookie.blob.extra_length > 0:
 
 print("")
 print("Getting all the entries")
-controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie))]
+controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie)).decode('utf8')]
 (msgs, ctrls) = remote_ldb.searchex(expression="(objectclass=*)", base=base, controls=controls)
 cont = 0
 if (len(ctrls)):
@@ -105,7 +105,7 @@ else:
     bigusn  = usn + 1000
 while (cont == "1"):
     print("")
-    controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie))]
+    controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie)).decode('utf8')]
     (msgs, ctrls) = remote_ldb.searchex(expression="(objectclass=*)", base=base, controls=controls)
     if (len(ctrls)):
         for ctl in ctrls:
@@ -121,7 +121,7 @@ cookie.blob.highwatermark.tmp_highest_usn = usn - 2
 if cookie.blob.extra_length > 0:
     print("here")
     cookie.blob.extra.ctr.cursors[0].highest_usn = bigusn - 1
-controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie))]
+controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie)).decode('utf8')]
 (msgs, ctrls) = remote_ldb.searchex(expression="(objectclass=*)", base=base, controls=controls)
 if (len(ctrls)):
     for ctl in ctrls:
@@ -136,7 +136,7 @@ cookie.blob.highwatermark.tmp_highest_usn = usn - 2
 if cookie.blob.extra_length > 0:
     cookie.blob.extra.ctr.cursors[0].source_dsa_invocation_id = misc.GUID("128a99bf-e2df-4832-ac0a-1fb625e530db")
     cookie.blob.extra.ctr.cursors[0].highest_usn = bigusn - 1
-controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie))]
+controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie)).decode('utf8'))
 (msgs, ctrls) = remote_ldb.searchex(expression="(objectclass=*)", base=base, controls=controls)
 if (len(ctrls)):
     for ctl in ctrls:
@@ -149,7 +149,7 @@ cookie.blob.highwatermark.highest_usn = 0
 cookie.blob.highwatermark.tmp_highest_usn = (usn - 2)
 if cookie.blob.extra_length > 0:
     cookie.blob.extra.ctr.cursors[0].highest_usn = (usn - 2)
-controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie))]
+controls=["dirsync:1:1:50:%s" % base64.b64encode(ndr_pack(cookie)).decode('utf8')]
 (msgs, ctrls) = remote_ldb.searchex(expression="(objectclass=*)", base=base, controls=controls)
 if (len(ctrls)):
     for ctl in ctrls:

--- a/source4/scripting/devel/speedtest.py
+++ b/source4/scripting/devel/speedtest.py
@@ -91,7 +91,7 @@ class SpeedTest(samba.tests.TestCase):
 dn: """ + user_dn + """
 sAMAccountName: """ + user_dn.split(",")[0][3:] + """
 objectClass: user
-unicodePwd:: """ + base64.b64encode(("\"%s\"" % self.user_pass).encode('utf-16-le')) + """
+unicodePwd:: """ + base64.b64encode(("\"%s\"" % self.user_pass).encode('utf-16-le')).decode('utf8') + """
 url: www.example.com
 """
         self.ldb_admin.add_ldif(ldif)


### PR DESCRIPTION
Some general py2/py3 compatibility fixes.
* b64encode results in bytes in python3 but we invariably treat the result in our code as string. This changes converts all usage of b64encode to decode the result, this will result in unicode in python2. Treating text as a text type (e.g. in python2) should ensure some sanity down the line (and should expose anywhere we don't really treat the result as a string)
* keys() now returns 'dict' class not a list, enclose result of .keys with list() function where it seems that makes sense
* xrange -> range Note: there is one instance of this where it might make a difference (see commit message) due to the potential amount of items in the range. Advice needed here, might need to drop one of these patches at the moment. Six apparently has a wrapper we could use instead (but CI doesn't support yet... I think) 
* md5 takes bytes in python3, some patches to make sure this is the case
* StringIO has moved to 'io' in python3, use the compat wrapper
* some missed exception compatibility fixes
* .next() method not longer exists in python3