### PR TITLE
traffic: add paged_results control for ldb search

### DIFF
--- a/python/samba/emulate/traffic.py
+++ b/python/samba/emulate/traffic.py
@@ -343,6 +343,7 @@ class ReplayContext(object):
 
         res = db.search(db.domain_dn(),
                         scope=ldb.SCOPE_SUBTREE,
+                        controls=["paged_results:1:1000"],
                         attrs=['dn'])
 
         # find a list of dns for each pattern

--- a/python/samba/emulate/traffic_packets.py
+++ b/python/samba/emulate/traffic_packets.py
@@ -326,7 +326,10 @@ def packet_ldap_3(packet, conversation, context):
     samdb = context.get_ldap_connection()
     dn = context.get_matching_dn(dn_sig)
 
-    samdb.search(dn, scope=int(scope), attrs=attrs.split(','))
+    samdb.search(dn,
+                 scope=int(scope),
+                 attrs=attrs.split(','),
+                 controls=["paged_results:1:1000"])
     return True
 
 


### PR DESCRIPTION
While there are more then 1000 records in the search result from Windows,
a `LDAP_SIZE_LIMIT_EXCEEDED` error will be returned.

Add paged_results control to fix.

Signed-off-by: Joe Guo <joeg@catalyst.net.nz>