### PR TITLE
traffic_replay: fetch domain from creds other than opts

### DIFF
--- a/script/traffic_replay
+++ b/script/traffic_replay
@@ -156,7 +156,7 @@ def main():
     lp = sambaopts.get_loadparm()
     creds = credopts.get_credentials(lp)
 
-    domain = opts.workgroup
+    domain = creds.get_domain()
     if domain:
         lp.set("workgroup", domain)
     else:


### PR DESCRIPTION
For traffic_replay script, when user provides `--workgroup` or `-W` option
from command line, it will be set on the creds option group, other than the
opts one. So while checking this option, we should check it against creds.

The previous code is actually loading domain from lp, which get data from the
smb.conf file.

Signed-off-by: Joe Guo <joeg@catalyst.net.nz>