### PR TITLE
Make ldb configuration --disable-python work

### DIFF
--- a/lib/ldb/wscript
+++ b/lib/ldb/wscript
@@ -127,9 +127,15 @@ def build(bld):
     bld.RECURSE('lib/tdb')
 
     if bld.env.standalone_ldb:
+        if not 'PACKAGE_VERSION' in bld.env:
+            bld.env.PACKAGE_VERSION = VERSION
+        bld.env.PKGCONFIGDIR = '${LIBDIR}/pkgconfig'
         private_library = False
     else:
         private_library = True
+    # we're not currently linking against the ldap libs, but ldb.pc.in
+    # has @LDAP_LIBS@
+    bld.env.LDAP_LIBS = ''
 
     LDB_MAP_SRC = bld.SUBDIR('ldb_map',
                              'ldb_map.c ldb_map_inbound.c ldb_map_outbound.c')
@@ -150,13 +156,6 @@ def build(bld):
     if bld.PYTHON_BUILD_IS_ENABLED():
         if not bld.CONFIG_SET('USING_SYSTEM_PYLDB_UTIL'):
             for env in bld.gen_python_environments(['PKGCONFIGDIR']):
-                # we're not currently linking against the ldap libs, but ldb.pc.in
-                # has @LDAP_LIBS@
-                bld.env.LDAP_LIBS = ''
-
-                if not 'PACKAGE_VERSION' in bld.env:
-                    bld.env.PACKAGE_VERSION = VERSION
-                    bld.env.PKGCONFIGDIR = '${LIBDIR}/pkgconfig'
 
                 name = bld.pyembed_libname('pyldb-util')
                 bld.SAMBA_LIBRARY(name,

--- a/script/autobuild.py
+++ b/script/autobuild.py
@@ -80,9 +80,10 @@ samba_configure_params = " --picky-developer ${PREFIX} ${EXTRA_PYTHON} --with-pr
 samba_libs_envvars =  "PYTHONPATH=${PYTHON_PREFIX}/site-packages:$PYTHONPATH"
 samba_libs_envvars += " PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${PREFIX_DIR}/lib/pkgconfig"
 samba_libs_envvars += " ADDITIONAL_CFLAGS='-Wmissing-prototypes'"
-samba_libs_configure_base = samba_libs_envvars + " ./configure --abi-check --enable-debug --picky-developer -C ${PREFIX} ${EXTRA_PYTHON}"
-samba_libs_configure_libs = samba_libs_configure_base + " --bundled-libraries=cmocka,NONE"
-samba_libs_configure_samba = samba_libs_configure_base + " --bundled-libraries=!talloc,!pytalloc-util,!tdb,!pytdb,!ldb,!pyldb,!pyldb-util,!tevent,!pytevent"
+samba_libs_configure_base = samba_libs_envvars + " ./configure --abi-check --enable-debug --picky-developer -C ${PREFIX}"
+samba_libs_configure_libs = samba_libs_configure_base + " --bundled-libraries=cmocka,NONE ${EXTRA_PYTHON}"
+samba_libs_configure_bundled_libs = " --bundled-libraries=!talloc,!pytalloc-util,!tdb,!pytdb,!ldb,!pyldb,!pyldb-util,!tevent,!pytevent"
+samba_libs_configure_samba = samba_libs_configure_base + samba_libs_configure_bundled_libs + " ${EXTRA_PYTHON}"
 
 if os.environ.get("AUTOBUILD_NO_EXTRA_PYTHON", "0") == "1":
     extra_python = ""
@@ -274,7 +275,30 @@ tasks = {
                       ("make", "make -j", "text/plain"),
                       ("install", "make install", "text/plain"),
                       ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
-                      ("clean", "make clean", "text/plain")
+                      ("clean", "make clean", "text/plain"),
+
+                      ("talloc-configure", "cd lib/talloc && " + samba_libs_configure_base + " --bundled-libraries=cmocka,NONE --disable-python", "text/plain"),
+                      ("talloc-make", "cd lib/talloc && make", "text/plain"),
+                      ("talloc-install", "cd lib/talloc && make install", "text/plain"),
+
+                      ("tdb-configure", "cd lib/tdb && " + samba_libs_configure_base + " --bundled-libraries=cmocka,NONE --disable-python", "text/plain"),
+                      ("tdb-make", "cd lib/tdb && make", "text/plain"),
+                      ("tdb-install", "cd lib/tdb && make install", "text/plain"),
+
+                      ("tevent-configure", "cd lib/tevent && " + samba_libs_configure_base + " --bundled-libraries=cmocka,NONE --disable-python", "text/plain"),
+                      ("tevent-make", "cd lib/tevent && make", "text/plain"),
+                      ("tevent-install", "cd lib/tevent && make install", "text/plain"),
+
+                      ("ldb-configure", "cd lib/ldb && " + samba_libs_configure_base + " --bundled-libraries=cmocka,NONE --disable-python", "text/plain"),
+                      ("ldb-make", "cd lib/ldb && make", "text/plain"),
+                      ("ldb-install", "cd lib/ldb && make install", "text/plain"),
+
+                      # retry against installed library packages
+                      ("libs-configure", samba_libs_configure_base + samba_libs_configure_bundled_libs + " --disable-python --without-ad-dc", "text/plain"),
+                      ("libs-make", "make -j", "text/plain"),
+                      ("libs-install", "make install", "text/plain"),
+                      ("libs-check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
+                      ("libs-clean", "make clean", "text/plain")
                       ],
 
 


### PR DESCRIPTION
Fix broken in ldb 1.3 --disable-python configuration option.