### PR TITLE
buildtools: Respect additional LIBPATH from python LDFLAGS

### DIFF
--- a/third_party/waf/wafadmin/Tools/python.py
+++ b/third_party/waf/wafadmin/Tools/python.py
@@ -253,7 +253,7 @@ LDVERSION = %r
 		result = conf.check(lib=name, uselib='PYEMBED', libpath=path)
 
 	if result:
-		env['LIBPATH_PYEMBED'] = path
+		env.append_unique('LIBPATH_PYEMBED', path)
 		env.append_value('LIB_PYEMBED', name)
 	else:
 		conf.log.write("\n\n### LIB NOT FOUND\n")


### PR DESCRIPTION
LDFLAGS variable, as comes from distutils.sysconfig.get_config_var,
contains -L<path> parameters on some systems. These flags
are correctly parsed and put to LIBPATH_PYEMBED, but, before this
change, they were overriden and thus ignored by the build
system. This change addresses this problem and fixes the build
on the systems where these flags are required.

Signed-off-by: Ivan A. Melnikov <iv@altlinux.org>