### PR TITLE
Rename samba_gpoupdate command to gpupdate

### DIFF
--- a/docs-xml/smbdotconf/domain/gpoupdatecommand.xml
+++ b/docs-xml/smbdotconf/domain/gpoupdatecommand.xml
@@ -5,7 +5,7 @@
                  xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
 <description>
 	<para>This option sets the command that is called to apply GPO policies.
-        The samba_gpoupdate script applies System Access and Kerberos Policies
+        The samba_gpupdate script applies System Access and Kerberos Policies
 	to the KDC. System Access policies set minPwdAge, maxPwdAge,
 	minPwdLength, and pwdProperties in the samdb. Kerberos Policies set
 	kdc:service ticket lifetime, kdc:user ticket lifetime, and kdc:renewal
@@ -13,6 +13,6 @@
 	</para>
 </description>
 
-<value type="default">&pathconfig.SCRIPTSBINDIR;/samba_gpoupdate</value>
+<value type="default">&pathconfig.SCRIPTSBINDIR;/samba_gpupdate</value>
 <value type="example">/usr/local/sbin/gpoupdate</value>
 </samba:parameter>

--- a/lib/param/loadparm.c
+++ b/lib/param/loadparm.c
@@ -2733,7 +2733,7 @@ struct loadparm_context *loadparm_init(TALLOC_CTX *mem_ctx)
 	lpcfg_do_global_parameter(lp_ctx, "require strong key", "True");
 	lpcfg_do_global_parameter(lp_ctx, "winbindd socket directory", dyn_WINBINDD_SOCKET_DIR);
 	lpcfg_do_global_parameter(lp_ctx, "ntp signd socket directory", dyn_NTP_SIGND_SOCKET_DIR);
-	lpcfg_do_global_parameter_var(lp_ctx, "gpo update command", "%s/samba_gpoupdate", dyn_SCRIPTSBINDIR);
+	lpcfg_do_global_parameter_var(lp_ctx, "gpo update command", "%s/samba_gpupdate", dyn_SCRIPTSBINDIR);
 	lpcfg_do_global_parameter_var(lp_ctx, "apply group policies", "False");
 	lpcfg_do_global_parameter_var(lp_ctx, "dns update command", "%s/samba_dnsupdate", dyn_SCRIPTSBINDIR);
 	lpcfg_do_global_parameter_var(lp_ctx, "spn update command", "%s/samba_spnupdate", dyn_SCRIPTSBINDIR);

--- a/selftest/target/Samba4.pm
+++ b/selftest/target/Samba4.pm
@@ -641,7 +641,7 @@ sub provision_raw_step1($$)
 	rndc command = true
 	dns update command = $ctx->{samba_dnsupdate}
 	spn update command = $ENV{SRCDIR_ABS}/source4/scripting/bin/samba_spnupdate -s $ctx->{smb_conf}
-	gpo update command = $ENV{SRCDIR_ABS}/source4/scripting/bin/samba_gpoupdate -s $ctx->{smb_conf} -H $ctx->{privatedir}/sam.ldb --machine
+	gpo update command = $ENV{SRCDIR_ABS}/source4/scripting/bin/samba_gpupdate -s $ctx->{smb_conf} -H $ctx->{privatedir}/sam.ldb --machine
 	dreplsrv:periodic_startup_interval = 0
 	dsdb:schema update allowed = yes
 

--- a/selftest/target/Samba4.pm
+++ b/selftest/target/Samba4.pm
@@ -641,7 +641,7 @@ sub provision_raw_step1($$)
 	rndc command = true
 	dns update command = $ctx->{samba_dnsupdate}
 	spn update command = $ENV{SRCDIR_ABS}/source4/scripting/bin/samba_spnupdate -s $ctx->{smb_conf}
-	gpo update command = $ENV{SRCDIR_ABS}/source4/scripting/bin/samba_gpupdate -s $ctx->{smb_conf} -H $ctx->{privatedir}/sam.ldb --machine
+	gpo update command = $ENV{SRCDIR_ABS}/source4/scripting/bin/samba_gpupdate -s $ctx->{smb_conf} -H $ctx->{privatedir}/sam.ldb --target=Computer
 	dreplsrv:periodic_startup_interval = 0
 	dsdb:schema update allowed = yes
 

--- a/source3/param/loadparm.c
+++ b/source3/param/loadparm.c
@@ -917,7 +917,7 @@ static void init_globals(struct loadparm_context *lp_ctx, bool reinit_globals)
 	Globals.dns_update_command = str_list_make_v3_const(NULL, s, NULL);
 	TALLOC_FREE(s);
 
-	s = talloc_asprintf(talloc_tos(), "%s/samba_gpoupdate", get_dyn_SCRIPTSBINDIR());
+	s = talloc_asprintf(talloc_tos(), "%s/samba_gpupdate", get_dyn_SCRIPTSBINDIR());
 	if (s == NULL) {
 		smb_panic("init_globals: ENOMEM");
 	}

--- a/source3/winbindd/winbindd_gpupdate.c
+++ b/source3/winbindd/winbindd_gpupdate.c
@@ -62,7 +62,7 @@ static void gpupdate_callback(struct tevent_context *ev,
 				gpupdate_cmd,
 				"-s",
 				smbconf,
-				"--machine",
+				"--target=Computer",
 				"--machine-pass",
 				NULL);
 	if (req == NULL) {

--- a/source4/scripting/bin/samba_gpupdate
+++ b/source4/scripting/bin/samba_gpupdate
@@ -39,7 +39,7 @@ from samba.gp_sec_ext import gp_sec_ext
 import logging
 
 if __name__ == "__main__":
-    parser = optparse.OptionParser('samba_gpoupdate [options]')
+    parser = optparse.OptionParser('samba_gpupdate [options]')
     sambaopts = options.SambaOptions(parser)
 
     # Get the command line options
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     session = system_session()
 
     # Set up logging
-    logger = logging.getLogger('samba_gpoupdate')
+    logger = logging.getLogger('samba_gpupdate')
     logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.setLevel(logging.CRITICAL)
     log_level = lp.log_level()

--- a/source4/scripting/bin/samba_gpupdate
+++ b/source4/scripting/bin/samba_gpupdate
@@ -49,8 +49,8 @@ if __name__ == "__main__":
     parser.add_option('-H', '--url', dest='url', help='URL for the samdb')
     parser.add_option('-X', '--unapply', help='Unapply Group Policy',
                       action='store_true')
-    parser.add_option('-M', '--machine', help='Apply machine policy',
-                      action='store_true', default=False)
+    parser.add_option('--target', default='Computer', help='{Computer | User}',
+                      choices=['Computer', 'User'])
     parser.add_option_group(credopts)
 
     # Set the options and the arguments
@@ -85,10 +85,10 @@ if __name__ == "__main__":
     store = GPOStorage(os.path.join(cache_dir, 'gpo.tdb'))
 
     gp_extensions = []
-    if opts.machine:
+    if opts.target == 'Computer':
         if lp.get('server role') == 'active directory domain controller':
             gp_extensions.append(gp_sec_ext(logger))
-    else:
+    elif opts.target == 'User':
         pass # User extensions
 
     # Get a live instance of Samba

--- a/source4/scripting/bin/wscript_build
+++ b/source4/scripting/bin/wscript_build
@@ -9,4 +9,4 @@ if bld.CONFIG_SET('AD_DC_BUILD_IS_ENABLED'):
                    'samba_upgradedns',
                    'gen_output.py']:
         bld.SAMBA_SCRIPT(script, pattern=script, installdir='.')
-bld.SAMBA_SCRIPT('samba_gpoupdate', pattern='samba_gpoupdate', installdir='.')
+bld.SAMBA_SCRIPT('samba_gpupdate', pattern='samba_gpupdate', installdir='.')

--- a/source4/scripting/man/samba_gpupdate.8.xml
+++ b/source4/scripting/man/samba_gpupdate.8.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
-<refentry id="samba_gpoupdate.8">
+<refentry id="samba_gpupdate.8">
 <refentryinfo><date>2017-07-11</date></refentryinfo>
 
 <refmeta>
@@ -12,17 +12,17 @@
 </refmeta>
 
 <refnamediv>
-	<refname>samba_gpoupdate</refname>
+	<refname>samba_gpupdate</refname>
 	<refpurpose>apply group policy</refpurpose>
 </refnamediv>
 
 <refsynopsisdiv>
 	<cmdsynopsis>
-		<command>samba_gpoupdate</command>
+		<command>samba_gpupdate</command>
 	</cmdsynopsis>
 
 	<cmdsynopsis>
-		<command>samba_gpoupdate</command>
+		<command>samba_gpupdate</command>
 		<arg choice="opt">
 		<replaceable>options</replaceable>
 		</arg>
@@ -37,7 +37,7 @@
 	<citerefentry><refentrytitle>samba</refentrytitle>
 	<manvolnum>1</manvolnum></citerefentry> suite.</para>
 
-	<para><command>samba_gpoupdate</command> a script for
+	<para><command>samba_gpupdate</command> a script for
 	applying and unapplying Group Policy. Group Policy
 	application is experimental. Currently this applies
 	password policies (minimum/maximum password age,

--- a/source4/scripting/man/samba_gpupdate.8.xml
+++ b/source4/scripting/man/samba_gpupdate.8.xml
@@ -59,6 +59,9 @@
 <para><option>-X</option>, <option>--unapply</option>
        Unapply Group Policy</para>
 
+<para><option>--target</option>
+       {Computer | User}</para>
+
 <para>Samba Common Options:</para>
 
 <para><option>-s </option>FILE, <option>--configfile</option>=<emphasis remap="I">FILE</emphasis>

--- a/source4/scripting/wscript_build
+++ b/source4/scripting/wscript_build
@@ -5,8 +5,8 @@ from samba_utils import MODE_755
 sbin_files = ''
 if bld.CONFIG_SET('AD_DC_BUILD_IS_ENABLED'):
     sbin_files = 'bin/samba_dnsupdate bin/samba_spnupdate bin/samba_upgradedns bin/samba_kcc '
-sbin_files += 'bin/samba_gpoupdate'
-man_files = 'man/samba_gpoupdate.8'
+sbin_files += 'bin/samba_gpupdate'
+man_files = 'man/samba_gpupdate.8'
 
 if sbin_files:
     bld.INSTALL_FILES('${SBINDIR}',


### PR DESCRIPTION
On a Windows client, this command is called 'gpupdate'. Also change the machine option to 'target', bringing the command more in line with the windows client command.