### PR TITLE
Cached Group Policy and client application

### DIFF
--- a/python/samba/gpclass.py
+++ b/python/samba/gpclass.py
@@ -423,6 +423,46 @@ def get_gpo_list(dc_hostname, creds, lp):
         gpos = ads.get_gpo_list(creds.get_username())
     return gpos
 
+FILE_ATTRIBUTE_DIRECTORY = 0x10
+def cache_gpo_dir(conn, cache, sub_dir):
+    loc_sub_dir = sub_dir.lower()
+    try:
+        os.makedirs(os.path.join(cache, loc_sub_dir), mode=0o755)
+    except OSError:
+        pass # File Exists
+    for fdata in conn.list(sub_dir):
+        if fdata['attrib'] & FILE_ATTRIBUTE_DIRECTORY:
+            cache_gpo_dir(conn, cache, os.path.join(sub_dir, fdata['name']))
+        else:
+            local_name = fdata['name'].lower()
+            with open(os.path.join(cache, loc_sub_dir, local_name), 'w') as f:
+                fname = os.path.join(sub_dir, fdata['name']).replace('/', '\\')
+                f.write(conn.loadfile(fname))
+
+def check_safe_path(path):
+    if 'sysvol' in path:
+        dirs = re.split('/|\\\\', path)
+        print(dirs)
+        dirs = dirs[dirs.index('sysvol')+1:]
+        if not '..' in dirs:
+            return os.path.join(*dirs)
+    raise OSError(path)
+
+def check_refresh_gpo_list(dc_hostname, lp, creds, gpos):
+    conn = smb.SMB(dc_hostname, 'sysvol', lp=lp, creds=creds, sign=True)
+    cache_path = lp.cache_path('gpo_cache')
+    for gpo in gpos:
+        if not gpo.file_sys_path:
+            continue
+        cache_gpo_dir(conn, cache_path, check_safe_path(gpo.file_sys_path))
+
+def gpo_version(lp, path, sysvol):
+    # gpo.gpo_get_sysvol_gpt_version() reads the GPT.INI from a local file,
+    # read from the gpo client cache.
+    gpt_path = lp.cache_path(os.path.join('gpo_cache', path))
+    local_path = os.path.join(gpt_path, 'gpt.ini')
+    return int(gpo.gpo_get_sysvol_gpt_version(os.path.dirname(local_path))[1])
+
 def apply_gp(lp, creds, test_ldb, logger, store, gp_extensions):
     gp_db = store.get_gplog(creds.get_username())
     dc_hostname = get_dc_hostname(creds, lp)
@@ -432,14 +472,19 @@ def apply_gp(lp, creds, test_ldb, logger, store, gp_extensions):
         logger.error('Error connecting to \'%s\' using SMB' % dc_hostname)
         raise
     gpos = get_gpo_list(dc_hostname, creds, lp)
+    try:
+        check_refresh_gpo_list(dc_hostname, lp, creds, gpos)
+    except:
+        logger.error('Failed downloading gpt cache from \'%s\' using SMB' \
+            % dc_hostname)
+        return
 
     for gpo_obj in gpos:
         guid = gpo_obj.name
         if guid == 'Local Policy':
             continue
-        path = os.path.join(lp.get('realm').lower(), 'Policies', guid)
-        local_path = os.path.join(lp.get("path", "sysvol"), path)
-        version = int(gpo.gpo_get_sysvol_gpt_version(local_path)[1])
+        path = os.path.join(lp.get('realm').lower(), 'policies', guid)
+        version = gpo_version(lp, path, sysvol)
         if version != store.get_int(guid):
             logger.info('GPO %s has changed' % guid)
             gp_db.state(GPOSTATE.APPLY)

--- a/source4/libcli/pysmb.c
+++ b/source4/libcli/pysmb.c
@@ -577,7 +577,7 @@ static PyObject *py_smb_new(PyTypeObject *type, PyObject *args, PyObject *kwargs
 	PyObject *py_creds = Py_None;
 	PyObject *py_lp = Py_None;
 	const char *kwnames[] = { "hostname", "service", "creds", "lp",
-				  "ntlmv2_auth", "use_spnego", NULL };
+				  "ntlmv2_auth", "use_spnego", "sign", NULL };
 	const char *hostname = NULL;
 	const char *service = NULL;
 	PyObject *smb;
@@ -588,11 +588,12 @@ static PyObject *py_smb_new(PyTypeObject *type, PyObject *args, PyObject *kwargs
 	struct smbcli_session_options session_options;
 	uint8_t ntlmv2_auth = 0xFF;
 	uint8_t use_spnego = 0xFF;
+	PyObject *sign = Py_False;
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "zz|OObb",
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "zz|OObbO",
 					 discard_const_p(char *, kwnames),
 					 &hostname, &service, &py_creds, &py_lp,
-					 &ntlmv2_auth, &use_spnego)) {
+					 &ntlmv2_auth, &use_spnego, &sign)) {
 		return NULL;
 	}
 
@@ -633,6 +634,9 @@ static PyObject *py_smb_new(PyTypeObject *type, PyObject *args, PyObject *kwargs
 	}
 	if (use_spnego != 0xFF) {
 		options.use_spnego = use_spnego;
+	}
+	if (PyObject_IsTrue(sign)) {
+		options.signing = SMB_SIGNING_REQUIRED;
 	}
 
 	status = do_smb_connect(spdata, spdata, hostname, service,

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -633,7 +633,7 @@ planpythontestsuite("chgdcpass:local", "samba.tests.samba_tool.dnscmd")
 planpythontestsuite("ad_dc_ntvfs:local", "samba.tests.dcerpc.rpcecho", py3_compatible=True)
 
 planoldpythontestsuite("nt4_dc", "samba.tests.netbios", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
-planoldpythontestsuite("ad_dc:local", "samba.tests.gpo", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
+planoldpythontestsuite("ad_dc:local", "samba.tests.gpo", extra_args=['-U"$USERNAME%$PASSWORD"'])
 planoldpythontestsuite("ad_dc:local", "samba.tests.dckeytab", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
 planoldpythontestsuite("ad_dc:local", "samba.tests.smb", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
 


### PR DESCRIPTION
On a client machine, we need to cache group policies before applying them. This also makes forcing policy possible when offline.
The cache path is determined using the lp.cach_path() function, which returns a cache directory within samba's cache, guaranteeing the cache has been created with all the correct permissions. The Group Policy Template (the gpo cache) is then downloaded to that cache using 0744 perms for the subdirs.
Client machines cannot read the GPT.INI and get the gpo versions without this patch, since they don't have access to the sysvol share locally (gpo_get_sysvol_gpt_version() reads from a local file).

There is also a test included which verifies that the cache download works.