### PR TITLE
Make Group Policy Exensible

### DIFF
--- a/python/samba/gp_ext_loader.py
+++ b/python/samba/gp_ext_loader.py
@@ -43,6 +43,7 @@ def get_gp_ext_from_module(name, mod):
     return None
 
 def get_gp_client_side_extensions(logger, smb_conf):
+    user_exts = []
     machine_exts = []
     gp_exts = list_gp_extensions(smb_conf)
     for gp_ext in gp_exts.values():
@@ -52,5 +53,9 @@ def get_gp_client_side_extensions(logger, smb_conf):
             machine_exts.append(ext)
             logger.info('Loaded machine extension from %s: %s'
                         % (gp_ext['DllName'], ext.__name__))
-    return machine_exts
+        if ext and gp_ext['UserPolicy']:
+            user_exts.append(ext)
+            logger.info('Loaded user extension from %s: %s'
+                        % (gp_ext['DllName'], ext.__name__))
+    return (machine_exts, user_exts)
 

--- a/python/samba/gp_ext_loader.py
+++ b/python/samba/gp_ext_loader.py
@@ -1,0 +1,56 @@
+# Group Policy Client Side Extension Loader
+# Copyright (C) David Mulder <dmulder@suse.com> 2018
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from samba.gpclass import list_gp_extensions
+
+try:
+    import importlib.util
+    def import_file(name, location):
+        try:
+            spec = importlib.util.spec_from_file_location(name, location)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        except AttributeError:
+            from importlib.machinery import SourceFileLoader
+            module = SourceFileLoader(name, location).load_module()
+        return module
+except ImportError:
+    import imp
+    def import_file(name, location):
+        return imp.load_source(name, location)
+
+def get_gp_ext_from_module(name, mod):
+    import inspect
+    if mod:
+        clses = inspect.getmembers(mod, inspect.isclass)
+        for cls in clses:
+            if cls[-1].__name__ == name:
+                return cls[-1]
+    return None
+
+def get_gp_client_side_extensions(logger, smb_conf):
+    machine_exts = []
+    gp_exts = list_gp_extensions(smb_conf)
+    for gp_ext in gp_exts.values():
+        module = import_file(gp_ext['ProcessGroupPolicy'], gp_ext['DllName'])
+        ext = get_gp_ext_from_module(gp_ext['ProcessGroupPolicy'], module)
+        if ext and gp_ext['MachinePolicy']:
+            machine_exts.append(ext)
+            logger.info('Loaded machine extension from %s: %s'
+                        % (gp_ext['DllName'], ext.__name__))
+    return machine_exts
+

--- a/python/samba/gpclass.py
+++ b/python/samba/gpclass.py
@@ -515,3 +515,31 @@ def register_gp_extension(guid, name, path,
     f.close()
 
     return True
+
+def unregister_gp_extension(guid, smb_conf=None):
+    # Check for valid guid
+    if not guid[0] == '{' or not guid[-1] == '}':
+        return False
+    try:
+        uuid = guid[1:-1]
+        UUID(uuid, version=4)
+    except:
+        return False
+
+    lp = LoadParm()
+    if smb_conf is not None:
+        lp.load(smb_conf)
+    else:
+        lp.load_default()
+    ext_conf = lp.cache_path('gpext.conf')
+    parser = ConfigParser()
+    parser.read(ext_conf)
+
+    if guid in parser.sections():
+        parser.remove_section(guid)
+
+    f = open(ext_conf, 'w')
+    parser.write(f)
+    f.close()
+
+    return True

--- a/python/samba/gpclass.py
+++ b/python/samba/gpclass.py
@@ -516,6 +516,27 @@ def register_gp_extension(guid, name, path,
 
     return True
 
+def list_gp_extensions(smb_conf=None):
+    lp = LoadParm()
+    if smb_conf is not None:
+        lp.load(smb_conf)
+    else:
+        lp.load_default()
+    ext_conf = lp.cache_path('gpext.conf')
+    parser = ConfigParser()
+    parser.read(ext_conf)
+
+    results = {}
+    for guid in parser.sections():
+        results[guid] = {}
+        results[guid]['DllName'] = parser.get(guid, 'DllName')
+        results[guid]['ProcessGroupPolicy'] = \
+            parser.get(guid, 'ProcessGroupPolicy')
+        results[guid]['MachinePolicy'] = \
+            not int(parser.get(guid, 'NoMachinePolicy'))
+        results[guid]['UserPolicy'] = not int(parser.get(guid, 'NoUserPolicy'))
+    return results
+
 def unregister_gp_extension(guid, smb_conf=None):
     # Check for valid guid
     if not guid[0] == '{' or not guid[-1] == '}':

--- a/python/samba/gpclass.py
+++ b/python/samba/gpclass.py
@@ -315,7 +315,12 @@ class gp_ext(object):
         # Fixing the bug where only some Linux Boxes capitalize MACHINE
         try:
             blist = afile.split('/')
-            idx = afile.lower().split('/').index('machine')
+            index = None
+            if 'machine' in afile.lower():
+                index = 'machine'
+            elif 'user' in afile.lower():
+                index = 'user'
+            idx = afile.lower().split('/').index(index)
             for case in [
                             blist[idx].upper(),
                             blist[idx].capitalize(),

--- a/python/samba/tests/gpo.py
+++ b/python/samba/tests/gpo.py
@@ -16,6 +16,8 @@
 
 import os
 from samba import gpo, tests
+from samba.gpclass import register_gp_extension, list_gp_extensions, \
+    unregister_gp_extension
 from samba.param import LoadParm
 
 poldir = r'\\addom.samba.example.com\sysvol\addom.samba.example.com\Policies'
@@ -74,4 +76,21 @@ class GPOTests(tests.TestCase):
             gpt.write(gpt_data % old_vers)
         assert gpo.gpo_get_sysvol_gpt_version(gpo_path)[1] == old_vers, \
           'gpo_get_sysvol_gpt_version() did not return the expected version'
+
+    def test_gpt_ext_register(self):
+        ext_path = '/home/dmulder/code/samba/bin/python/samba/gp_sec_ext.py'
+        ext_guid = '{827D319E-6EAC-11D2-A4EA-00C04F79F83A}'
+        register_gp_extension(ext_guid, 'gp_sec_ext', ext_path,
+                              smb_conf=self.lp.configfile,
+                              machine=True, user=False)
+        gp_exts = list_gp_extensions(self.lp.configfile)
+        assert ext_guid in gp_exts.keys(), \
+            'Failed to list gp exts from registry'
+        assert gp_exts[ext_guid]['DllName'] == ext_path, \
+            'Failed to list gp exts from registry'
+
+        unregister_gp_extension(ext_guid)
+        gp_exts = list_gp_extensions(self.lp.configfile)
+        assert ext_guid not in gp_exts.keys(), \
+            'Failed to unregister gp exts from registry'
 

--- a/source4/scripting/bin/samba_gpoupdate
+++ b/source4/scripting/bin/samba_gpoupdate
@@ -36,6 +36,7 @@ except:
     SamDB = None
 from samba.gpclass import apply_gp, unapply_gp, GPOStorage
 from samba.gp_sec_ext import gp_sec_ext
+from samba.gp_ext_loader import get_gp_client_side_extensions
 import logging
 
 if __name__ == "__main__":
@@ -84,10 +85,13 @@ if __name__ == "__main__":
     cache_dir = lp.get('cache directory')
     store = GPOStorage(os.path.join(cache_dir, 'gpo.tdb'))
 
+    machine_exts = get_gp_client_side_extensions(logger, lp.configfile)
     gp_extensions = []
     if opts.machine:
         if lp.get('server role') == 'active directory domain controller':
             gp_extensions.append(gp_sec_ext(logger))
+        for ext in machine_exts:
+            gp_extensions.append(ext(logger))
     else:
         pass # User extensions
 

--- a/source4/scripting/bin/samba_gpoupdate
+++ b/source4/scripting/bin/samba_gpoupdate
@@ -85,7 +85,8 @@ if __name__ == "__main__":
     cache_dir = lp.get('cache directory')
     store = GPOStorage(os.path.join(cache_dir, 'gpo.tdb'))
 
-    machine_exts = get_gp_client_side_extensions(logger, lp.configfile)
+    machine_exts, user_exts = get_gp_client_side_extensions(logger,
+                                                            lp.configfile)
     gp_extensions = []
     if opts.machine:
         if lp.get('server role') == 'active directory domain controller':
@@ -93,7 +94,8 @@ if __name__ == "__main__":
         for ext in machine_exts:
             gp_extensions.append(ext(logger))
     else:
-        pass # User extensions
+        for ext in user_exts:
+            gp_extensions.append(ext(logger))
 
     # Get a live instance of Samba
     if SamDB:

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -633,7 +633,7 @@ planpythontestsuite("chgdcpass:local", "samba.tests.samba_tool.dnscmd")
 planpythontestsuite("ad_dc_ntvfs:local", "samba.tests.dcerpc.rpcecho", py3_compatible=True)
 
 planoldpythontestsuite("nt4_dc", "samba.tests.netbios", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
-planoldpythontestsuite("ad_dc:local", "samba.tests.gpo", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
+planoldpythontestsuite("ad_dc:local", "samba.tests.gpo", extra_args=['-U"$USERNAME%$PASSWORD"'])
 planoldpythontestsuite("ad_dc:local", "samba.tests.dckeytab", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
 planoldpythontestsuite("ad_dc:local", "samba.tests.smb", extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
 


### PR DESCRIPTION
Trying this a little different way now (third set of patches for this feature).
This works *mostly* the way it's done on a Windows client.
Normally on a windows client, Group Policy client side extensions are registered via the Windows Registry in designated key, but Andrew pointed out that this is unreliable in samba. So I've moved the registered extensions to a configuration file in the cache path. Another advantage to this approach is that it can all be written in python code now (so we don't have to deal with the python c-api).
I've also added input validation so we don't end up with garbage in the gpext config file.
Testing is also included.

See the MS spec here regarding how CSE registration works (under Creating and Registering):
https://msdn.microsoft.com/en-us/library/aa374288(v=vs.85).aspx