### PR TITLE
Ntacls backup and restore

### DIFF
--- a/python/samba/tests/ntacls.py
+++ b/python/samba/tests/ntacls.py
@@ -24,53 +24,51 @@ from samba.dcerpc import security
 from samba.tests import TestCaseInTempDir, SkipTest
 import os
 
+NTACL_SDDL = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
+DOMAIN_SID = "S-1-5-21-2212615479-2695158682-2101375467"
+
+
 class NtaclsTests(TestCaseInTempDir):
 
     def test_setntacl(self):
         lp = LoadParm()
-        acl = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
         open(self.tempf, 'w').write("empty")
         lp.set("posix:eadb",os.path.join(self.tempdir,"eadbtest.tdb"))
-        setntacl(lp, self.tempf, acl, "S-1-5-21-2212615479-2695158682-2101375467")
+        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID)
         os.unlink(os.path.join(self.tempdir,"eadbtest.tdb"))
 
     def test_setntacl_getntacl(self):
         lp = LoadParm()
-        acl = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
         open(self.tempf, 'w').write("empty")
         lp.set("posix:eadb",os.path.join(self.tempdir,"eadbtest.tdb"))
-        setntacl(lp,self.tempf,acl,"S-1-5-21-2212615479-2695158682-2101375467")
+        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID)
         facl = getntacl(lp,self.tempf)
         anysid = security.dom_sid(security.SID_NT_SELF)
-        self.assertEquals(facl.as_sddl(anysid),acl)
+        self.assertEquals(facl.as_sddl(anysid), NTACL_SDDL)
         os.unlink(os.path.join(self.tempdir,"eadbtest.tdb"))
 
     def test_setntacl_getntacl_param(self):
         lp = LoadParm()
-        acl = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
         open(self.tempf, 'w').write("empty")
-        setntacl(lp,self.tempf,acl,"S-1-5-21-2212615479-2695158682-2101375467","tdb",os.path.join(self.tempdir,"eadbtest.tdb"))
+        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID,"tdb", os.path.join(self.tempdir,"eadbtest.tdb"))
         facl=getntacl(lp,self.tempf,"tdb",os.path.join(self.tempdir,"eadbtest.tdb"))
         domsid=security.dom_sid(security.SID_NT_SELF)
-        self.assertEquals(facl.as_sddl(domsid),acl)
+        self.assertEquals(facl.as_sddl(domsid), NTACL_SDDL)
         os.unlink(os.path.join(self.tempdir,"eadbtest.tdb"))
 
     def test_setntacl_invalidbackend(self):
         lp = LoadParm()
-        acl = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
         open(self.tempf, 'w').write("empty")
-        self.assertRaises(XattrBackendError, setntacl, lp, self.tempf, acl, "S-1-5-21-2212615479-2695158682-2101375467","ttdb", os.path.join(self.tempdir,"eadbtest.tdb"))
+        self.assertRaises(XattrBackendError, setntacl, lp, self.tempf, NTACL_SDDL, DOMAIN_SID, "ttdb", os.path.join(self.tempdir,"eadbtest.tdb"))
 
     def test_setntacl_forcenative(self):
         if os.getuid() == 0:
             raise SkipTest("Running test as root, test skipped")
         lp = LoadParm()
-        acl = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
         open(self.tempf, 'w').write("empty")
         lp.set("posix:eadb", os.path.join(self.tempdir,"eadbtest.tdb"))
-        self.assertRaises(Exception, setntacl, lp, self.tempf ,acl,
-            "S-1-5-21-2212615479-2695158682-2101375467","native")
-
+        self.assertRaises(Exception, setntacl, lp, self.tempf, NTACL_SDDL,
+            DOMAIN_SID, "native")
 
     def setUp(self):
         super(NtaclsTests, self).setUp()

--- a/python/samba/tests/ntacls.py
+++ b/python/samba/tests/ntacls.py
@@ -18,57 +18,18 @@
 
 """Tests for samba.ntacls."""
 
+import os
+
 from samba.ntacls import setntacl, getntacl, XattrBackendError
 from samba.param import LoadParm
 from samba.dcerpc import security
 from samba.tests import TestCaseInTempDir, SkipTest
-import os
 
 NTACL_SDDL = "O:S-1-5-21-2212615479-2695158682-2101375467-512G:S-1-5-21-2212615479-2695158682-2101375467-513D:(A;OICI;0x001f01ff;;;S-1-5-21-2212615479-2695158682-2101375467-512)"
 DOMAIN_SID = "S-1-5-21-2212615479-2695158682-2101375467"
 
 
 class NtaclsTests(TestCaseInTempDir):
-
-    def test_setntacl(self):
-        lp = LoadParm()
-        open(self.tempf, 'w').write("empty")
-        lp.set("posix:eadb",os.path.join(self.tempdir,"eadbtest.tdb"))
-        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID)
-        os.unlink(os.path.join(self.tempdir,"eadbtest.tdb"))
-
-    def test_setntacl_getntacl(self):
-        lp = LoadParm()
-        open(self.tempf, 'w').write("empty")
-        lp.set("posix:eadb",os.path.join(self.tempdir,"eadbtest.tdb"))
-        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID)
-        facl = getntacl(lp,self.tempf)
-        anysid = security.dom_sid(security.SID_NT_SELF)
-        self.assertEquals(facl.as_sddl(anysid), NTACL_SDDL)
-        os.unlink(os.path.join(self.tempdir,"eadbtest.tdb"))
-
-    def test_setntacl_getntacl_param(self):
-        lp = LoadParm()
-        open(self.tempf, 'w').write("empty")
-        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID,"tdb", os.path.join(self.tempdir,"eadbtest.tdb"))
-        facl=getntacl(lp,self.tempf,"tdb",os.path.join(self.tempdir,"eadbtest.tdb"))
-        domsid=security.dom_sid(security.SID_NT_SELF)
-        self.assertEquals(facl.as_sddl(domsid), NTACL_SDDL)
-        os.unlink(os.path.join(self.tempdir,"eadbtest.tdb"))
-
-    def test_setntacl_invalidbackend(self):
-        lp = LoadParm()
-        open(self.tempf, 'w').write("empty")
-        self.assertRaises(XattrBackendError, setntacl, lp, self.tempf, NTACL_SDDL, DOMAIN_SID, "ttdb", os.path.join(self.tempdir,"eadbtest.tdb"))
-
-    def test_setntacl_forcenative(self):
-        if os.getuid() == 0:
-            raise SkipTest("Running test as root, test skipped")
-        lp = LoadParm()
-        open(self.tempf, 'w').write("empty")
-        lp.set("posix:eadb", os.path.join(self.tempdir,"eadbtest.tdb"))
-        self.assertRaises(Exception, setntacl, lp, self.tempf, NTACL_SDDL,
-            DOMAIN_SID, "native")
 
     def setUp(self):
         super(NtaclsTests, self).setUp()
@@ -78,3 +39,47 @@ class NtaclsTests(TestCaseInTempDir):
     def tearDown(self):
         os.unlink(self.tempf)
         super(NtaclsTests, self).tearDown()
+
+    def test_setntacl(self):
+        lp = LoadParm()
+        open(self.tempf, 'w').write("empty")
+        lp.set("posix:eadb", os.path.join(self.tempdir, "eadbtest.tdb"))
+        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID)
+        os.unlink(os.path.join(self.tempdir, "eadbtest.tdb"))
+
+    def test_setntacl_getntacl(self):
+        lp = LoadParm()
+        open(self.tempf, 'w').write("empty")
+        lp.set("posix:eadb", os.path.join(self.tempdir, "eadbtest.tdb"))
+        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID)
+        facl = getntacl(lp, self.tempf)
+        anysid = security.dom_sid(security.SID_NT_SELF)
+        self.assertEquals(facl.as_sddl(anysid), NTACL_SDDL)
+        os.unlink(os.path.join(self.tempdir, "eadbtest.tdb"))
+
+    def test_setntacl_getntacl_param(self):
+        lp = LoadParm()
+        open(self.tempf, 'w').write("empty")
+        setntacl(lp, self.tempf, NTACL_SDDL, DOMAIN_SID, "tdb",
+                 os.path.join(self.tempdir, "eadbtest.tdb"))
+        facl = getntacl(lp, self.tempf, "tdb", os.path.join(
+            self.tempdir, "eadbtest.tdb"))
+        domsid = security.dom_sid(security.SID_NT_SELF)
+        self.assertEquals(facl.as_sddl(domsid), NTACL_SDDL)
+        os.unlink(os.path.join(self.tempdir, "eadbtest.tdb"))
+
+    def test_setntacl_invalidbackend(self):
+        lp = LoadParm()
+        open(self.tempf, 'w').write("empty")
+        self.assertRaises(XattrBackendError, setntacl, lp, self.tempf,
+                          NTACL_SDDL, DOMAIN_SID, "ttdb",
+                          os.path.join(self.tempdir, "eadbtest.tdb"))
+
+    def test_setntacl_forcenative(self):
+        if os.getuid() == 0:
+            raise SkipTest("Running test as root, test skipped")
+        lp = LoadParm()
+        open(self.tempf, 'w').write("empty")
+        lp.set("posix:eadb", os.path.join(self.tempdir, "eadbtest.tdb"))
+        self.assertRaises(Exception, setntacl, lp, self.tempf, NTACL_SDDL,
+                          DOMAIN_SID, "native")

--- a/python/samba/tests/ntacls_backup.py
+++ b/python/samba/tests/ntacls_backup.py
@@ -1,0 +1,179 @@
+# Unix SMB/CIFS implementation. Tests for ntacls manipulation
+# Copyright (C) Andrew Bartlett 2018
+# Copyright (C) Joe Guo <joeg@catalyst.net.nz> 2018
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Tests for samba ntacls backup"""
+import os
+
+from samba import smb
+from samba.samba3 import smbd
+from samba import samdb
+from samba import ntacls
+
+from samba.auth import system_session
+from samba.param import LoadParm
+from samba.dcerpc import security
+from samba.tests import TestCaseInTempDir
+
+
+class NtaclsBackupRestoreTests(TestCaseInTempDir):
+    """
+    Tests for NTACLs backup and restore.
+    """
+
+    def setUp(self):
+        super(NtaclsBackupRestoreTests, self).setUp()
+
+        self.server = os.environ["SERVER"]  # addc
+        samdb_url='ldap://' + self.server
+
+        self.service = 'test1'  # service/share to test
+        # root path for service
+        self.service_root = os.path.join(
+            os.environ["LOCAL_PATH"], self.service)
+
+        self.smb_conf_path = os.environ['SMB_CONF_PATH']
+        self.dom_sid = security.dom_sid(os.environ['DOMSID'])
+
+        self.creds = self.insta_creds(template=self.get_credentials())
+
+        # helper will load conf into lp, that's how smbd can find services.
+        self.ntacls_helper = ntacls.NtaclsHelper(
+            self.service, samdb_url,
+            self.smb_conf_path, self.dom_sid)
+
+        self.lp = self.ntacls_helper.lp
+
+        self.samdb_conn = samdb.SamDB(
+            url=samdb_url, session_info=system_session(),
+            credentials=self.creds, lp=self.lp)
+
+        self.smb_conn = smb.SMB(
+            self.server, self.service, lp=self.lp, creds=self.creds)
+
+        self.smb_helper = ntacls.SMBHelper(self.smb_conn, self.dom_sid)
+
+        self.tarfile_path = '/tmp/ntacls-backup.tar.gz'
+
+        # an example file tree
+        self.tree = {
+            'file0.txt': b'test file0',
+            'dir1': {
+                'file1.txt': b'test file1',
+                'dir2': {}  # an empty dir in dir
+            },
+        }
+
+        self._delete_tarfile()
+        self.smb_helper.delete_tree()
+
+        self.smb_helper.create_tree(self.tree)
+        self._check_tree()
+        # keep a copy of ntacls after tree just created
+        self.original_ntacls = self.smb_helper.get_ntacls()
+
+    def tearDown(self):
+        self._delete_tarfile()
+        self.smb_helper.delete_tree()
+        super(NtaclsBackupRestoreTests, self).tearDown()
+
+    def _delete_tarfile(self):
+        try:
+            os.remove(self.tarfile_path)
+        except OSError:
+            pass
+
+    def _check_tarfile(self):
+        self.assertTrue(os.path.isfile(self.tarfile_path))
+
+    def _check_tree(self):
+        actual_tree = self.smb_helper.get_tree()
+        self.assertDictEqual(self.tree, actual_tree)
+
+    def test_smbd_mkdir(self):
+        """
+        A smoke test for smbd.mkdir API
+        """
+
+        dirpath = os.path.join(self.service_root, 'a-dir')
+        smbd.mkdir(dirpath, self.service)
+        self.assertTrue(os.path.isdir(dirpath))
+
+    def test_smbd_create_file(self):
+        """
+        A smoke test for smbd.create_file API
+        """
+
+        filepath = os.path.join(self.service_root, 'a-file')
+        smbd.create_file(filepath, self.service)
+        self.assertTrue(os.path.isfile(filepath))
+
+    def test_compare_getntacl(self):
+        """
+        Ntacls get from different ways should be the same
+        """
+
+        file_name = 'file0.txt'
+        file_path = os.path.join(self.service_root, file_name)
+
+        sd0 = self.smb_helper.get_acl(file_name, as_sddl=True)
+
+        sd1 = self.ntacls_helper.getntacl(
+            file_path, as_sddl=True, direct_db_access=False)
+
+        sd2 = self.ntacls_helper.getntacl(
+            file_path, as_sddl=True, direct_db_access=True)
+
+        self.assertEquals(sd0, sd1)
+        self.assertEquals(sd1, sd2)
+
+    def test_backup_online(self):
+        """
+        Backup service online, delete files, restore and check.
+        """
+        ntacls.backup_online(
+            self.smb_conn, self.tarfile_path, self.dom_sid)
+        self._check_tarfile()
+
+        self.smb_helper.delete_tree()
+        ntacls.backup_restore(
+            self.tarfile_path, self.service_root,
+            self.samdb_conn, self.smb_conf_path)
+        self._check_tree()
+
+        # compare ntacls after restored
+        self.assertDictEqual(
+            self.original_ntacls, self.smb_helper.get_ntacls())
+
+    def test_backup_offline(self):
+        """
+        Backup service offline, delete files, restore and check.
+        """
+        ntacls.backup_offline(
+            self.service_root, self.tarfile_path,
+            self.samdb_conn, self.smb_conf_path)
+        self._check_tarfile()
+
+        self.smb_helper.delete_tree()
+        ntacls.backup_restore(
+            self.tarfile_path, self.service_root,
+            self.samdb_conn, self.smb_conf_path)
+        self._check_tree()
+
+        # compare ntacls after restored
+        self.assertDictEqual(
+            self.original_ntacls, self.smb_helper.get_ntacls())

--- a/python/samba/tests/smb.py
+++ b/python/samba/tests/smb.py
@@ -53,6 +53,14 @@ class SMBTests(samba.tests.TestCase):
         self.assertIn('Policies',ls,
             msg='"Policies" directory not found in sysvol')
 
+    def test_unlink(self):
+        """
+        The smb.unlink API should delete file
+        """
+        self.conn.savefile(test_file, binary_contents);
+        self.conn.unlink(test_file)
+        self.assertFalse(self.conn.chkpath(test_file))
+
     def test_save_load_text(self):
 
         self.conn.savefile(test_file, test_contents.encode('utf8'))

--- a/source3/smbd/pysmbd.c
+++ b/source3/smbd/pysmbd.c
@@ -754,6 +754,41 @@ static PyObject *py_smbd_mkdir(PyObject *self, PyObject *args, PyObject *kwargs)
 	Py_RETURN_NONE;
 }
 
+
+/*
+  Create an empty file
+ */
+static PyObject *py_smbd_create_file(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	const char * const kwnames[] = { "fname", "service", NULL };
+	char *fname, *service = NULL;
+	TALLOC_CTX *frame = talloc_stackframe();
+	struct connection_struct *conn = NULL;
+	struct files_struct *fsp = NULL;
+	NTSTATUS status;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|z", discard_const_p(char *, kwnames),
+					 &fname, &service)) {
+		TALLOC_FREE(frame);
+		return NULL;
+	}
+
+	conn = get_conn_tos(service);
+	if (!conn) {
+		TALLOC_FREE(frame);
+		return NULL;
+	}
+
+	status = init_files_struct(fname, conn, O_CREAT|O_EXCL|O_RDWR, &fsp);
+	if (!NT_STATUS_IS_OK(status)) {
+		DEBUG(0,("init_files_struct failed: %s\n", nt_errstr(status)));
+	}
+
+	TALLOC_FREE(frame);
+	Py_RETURN_NONE;
+}
+
+
 static PyMethodDef py_smbd_methods[] = {
 	{ "have_posix_acls",
 		(PyCFunction)py_smbd_have_posix_acls, METH_NOARGS,
@@ -781,6 +816,9 @@ static PyMethodDef py_smbd_methods[] = {
 		NULL },
 	{ "mkdir",
 		(PyCFunction)py_smbd_mkdir, METH_VARARGS|METH_KEYWORDS,
+		NULL },
+	{ "create_file",
+		(PyCFunction)py_smbd_create_file, METH_VARARGS|METH_KEYWORDS,
 		NULL },
 	{ NULL }
 };

--- a/source4/libcli/pysmb.c
+++ b/source4/libcli/pysmb.c
@@ -258,6 +258,27 @@ static PyObject *py_smb_rmdir(PyObject *self, PyObject *args)
 	Py_RETURN_NONE;
 }
 
+
+/*
+ * Remove a file
+ */
+static PyObject *py_smb_unlink(PyObject *self, PyObject *args)
+{
+	NTSTATUS status;
+	const char *filename;
+	struct smb_private_data *spdata;
+
+	if (!PyArg_ParseTuple(args, "s:unlink", &filename)) {
+		return NULL;
+	}
+
+	spdata = pytalloc_get_ptr(self);
+	status = smbcli_unlink(spdata->tree, filename);
+	PyErr_NTSTATUS_IS_ERR_RAISE(status);
+
+	Py_RETURN_NONE;
+}
+
 /*
  * Remove a directory and all its contents
  */
@@ -551,6 +572,9 @@ FILE_ATTRIBUTE_ARCHIVE\n\n \
 	{ "rmdir", py_smb_rmdir, METH_VARARGS,
 		"rmdir(path) -> None\n\n \
 		Delete a directory." },
+	{ "unlink", py_smb_unlink, METH_VARARGS,
+		"unlink(path) -> None\n\n \
+		Delete a file." },
 	{ "deltree", py_smb_deltree, METH_VARARGS,
 		"deltree(path) -> None\n\n \
 		Delete a directory and all its contents." },

--- a/source4/selftest/tests.py
+++ b/source4/selftest/tests.py
@@ -641,6 +641,10 @@ planoldpythontestsuite(
     "ad_dc_ntvfs:local", "samba.tests.dcerpc.registry",
     extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
 
+planoldpythontestsuite(
+    "ad_dc:local", "samba.tests.ntacls_backup",
+    extra_args=['-U"$USERNAME%$PASSWORD"'], py3_compatible=True)
+
 planoldpythontestsuite("ad_dc_ntvfs", "samba.tests.dcerpc.dnsserver", extra_args=['-U"$USERNAME%$PASSWORD"'])
 planoldpythontestsuite("ad_dc", "samba.tests.dcerpc.dnsserver", extra_args=['-U"$USERNAME%$PASSWORD"'])
 planoldpythontestsuite("chgdcpass", "samba.tests.dcerpc.raw_protocol", extra_args=['-U"$USERNAME%$PASSWORD"'])


### PR DESCRIPTION
Add following functions to samba.ntacls.py:

- backup_online: backup files and ntacls for a service/share to a tarfile via smb connection with pysmb API
- backup_offline: backup files and ntacls for a service/share to a tarfile via disk path with pysmbd API
- backup_restore: restore either of the above backup from a tarfile with pysmbd API
20180619 update:
- Compare ntacl sddl str before and after restore.

To make these work, extended `pysmb.c` and `pysmbd.c`.

Tests added in `samba.tests.ntacls.py`.

gitlab ci passed at:
https://gitlab.com/catalyst-samba/samba/pipelines/24028523