### PR TITLE
MAN: Adding entry for net ads lookup

### DIFF
--- a/docs-xml/manpages/net.8.xml
+++ b/docs-xml/manpages/net.8.xml
@@ -551,6 +551,12 @@ account in server manager first.</para>
 <para>Create specified group.</para>
 
 </refsect3>
+<refsect3>
+<title>[ADS] LOOKUP</title>
+
+<para>Lookup the closest Domain Controller in our domain and retrieve server information about it.</para>
+
+</refsect3>
 </refsect2>
 
 <refsect2>


### PR DESCRIPTION
There is no man page description for net ads lookup.
This PR adds entry for the same.