### PR TITLE
Don't encode the multiarch name into the pytalloc-util library name

### DIFF
--- a/third_party/waf/wafadmin/Tools/python.py
+++ b/third_party/waf/wafadmin/Tools/python.py
@@ -6,6 +6,7 @@
 "Python support"
 
 import os, sys
+import re
 import TaskGen, Utils, Options
 from Logs import debug, warn, info
 from TaskGen import extension, before, after, feature
@@ -179,6 +180,8 @@ def check_python_headers(conf, mandatory=True):
 	except RuntimeError:
 		conf.fatal("Python development headers not found (-v for details).")
 
+	if re.match('\.cpython-3.*\.so$', python_SO):
+		python_SO = ".python%s.so" % python_LDVERSION
 	conf.log.write("""Configuration returned from %r:
 python_prefix = %r
 python_SO = %r


### PR DESCRIPTION
For example on arm64:
libpytalloc-util.cpython-36m-aarch64-linux-gnu.so -> libpytalloc-util.python3.6m.so

This fixes FTBFS due to different symbols.

Bug-Debian: https://bugs.debian.org/902883

Signed-off-by: Mathieu Parent <math.parent@gmail.com>

See also #110.