### PR TITLE
waf: libtdb: set version in dynlib on OSX (for Homebrew packaging)

### DIFF
--- a/buildtools/wafsamba/wafsamba.py
+++ b/buildtools/wafsamba/wafsamba.py
@@ -1018,6 +1018,24 @@ def apply_bundle_remove_dynamiclib_patch(self):
         if not getattr(self,'vnum',None):
             try:
                 self.env['LINKFLAGS'].remove('-dynamiclib')
+
+                # Only try to remove these if -dynamiclib was preset, i.e. no exception above
+                try:
+                    arg_idx = self.env['LINKFLAGS'].index('-compatibility_version')
+                    self.env['LINKFLAGS'].pop(arg_idx) # the argument
+                    self.env['LINKFLAGS'].pop(arg_idx) # the subargument
+                except ValueError:
+                    pass
+                try:
+                    arg_idx = self.env['LINKFLAGS'].index('-current_version')
+                    self.env['LINKFLAGS'].pop(arg_idx) # the argument
+                    self.env['LINKFLAGS'].pop(arg_idx) # the subargument
+                except ValueError:
+                    pass
+            except ValueError:
+                pass
+
+	    try:
                 self.env['LINKFLAGS'].remove('-single_module')
             except ValueError:
                 pass

--- a/third_party/waf/wafadmin/Tools/gcc.py
+++ b/third_party/waf/wafadmin/Tools/gcc.py
@@ -94,8 +94,8 @@ def gcc_modifier_cygwin(conf):
 @conftest
 def gcc_modifier_darwin(conf):
 	v = conf.env
-	v['shlib_CCFLAGS']       = ['-fPIC', '-compatibility_version', '1', '-current_version', '1']
-	v['shlib_LINKFLAGS']     = ['-dynamiclib']
+	v['shlib_CCFLAGS']       = ['-fPIC']
+	v['shlib_LINKFLAGS']     = ['-dynamiclib', '-compatibility_version', '1', '-current_version', '1']
 	v['shlib_PATTERN']       = 'lib%s.dylib'
 
 	v['staticlib_LINKFLAGS'] = []

--- a/third_party/waf/wafadmin/Tools/gxx.py
+++ b/third_party/waf/wafadmin/Tools/gxx.py
@@ -92,8 +92,8 @@ def gxx_modifier_cygwin(conf):
 @conftest
 def gxx_modifier_darwin(conf):
 	v = conf.env
-	v['shlib_CXXFLAGS']      = ['-fPIC', '-compatibility_version', '1', '-current_version', '1']
-	v['shlib_LINKFLAGS']     = ['-dynamiclib']
+	v['shlib_CXXFLAGS']      = ['-fPIC']
+	v['shlib_LINKFLAGS']     = ['-dynamiclib', '-compatibility_version', '1', '-current_version', '1']
 	v['shlib_PATTERN']       = 'lib%s.dylib'
 
 	v['staticlib_LINKFLAGS'] = []

--- a/third_party/waf/wafadmin/Tools/osx.py
+++ b/third_party/waf/wafadmin/Tools/osx.py
@@ -162,6 +162,24 @@ def apply_bundle_remove_dynamiclib(self):
 		if not getattr(self, 'vnum', None):
 			try:
 				self.env['LINKFLAGS'].remove('-dynamiclib')
+
+				# Only try to remove these if -dynamiclib was preset, i.e. no exception above
+				try:
+				    arg_idx = self.env['LINKFLAGS'].index('-compatibility_version')
+				    self.env['LINKFLAGS'].pop(arg_idx) # the argument
+				    self.env['LINKFLAGS'].pop(arg_idx) # the subargument
+				except ValueError:
+				    pass
+				try:
+				    arg_idx = self.env['LINKFLAGS'].index('-current_version')
+				    self.env['LINKFLAGS'].pop(arg_idx) # the argument
+				    self.env['LINKFLAGS'].pop(arg_idx) # the subargument
+				except ValueError:
+				    pass
+			except ValueError:
+				pass
+
+			try:
 				self.env['LINKFLAGS'].remove('-single_module')
 			except ValueError:
 				pass

--- a/third_party/waf/wafadmin/Tools/python.py
+++ b/third_party/waf/wafadmin/Tools/python.py
@@ -261,7 +261,7 @@ LDVERSION = %r
 	# under certain conditions, python extensions must link to
 	# python libraries, not just python embedding programs.
 	if (sys.platform == 'win32' or sys.platform.startswith('os2')
-		or sys.platform == 'darwin' or Py_ENABLE_SHARED):
+		or Py_ENABLE_SHARED):
 		env['LIBPATH_PYEXT'] = env['LIBPATH_PYEMBED']
 		env['LIB_PYEXT'] = env['LIB_PYEMBED']
 


### PR DESCRIPTION
This patchset is needed to build libtdb on OS X via Homebrew. To get the brew formula for libtdb into Homebrew core repository, Homebrew requires patches to be merged upstream.

On OSX, without this patch `-compatibility_version` and `-current-version` are
passed to clang during compilationg and not during linking. The resulting
libtdb.dynlib ends up without versions set (`otool -l` reports them as 0.0.0).
I don't think adding these to compile flags is useful at all, clang ignores
them. Not having version set is not fatal, but the current code already
attempts to set it -- this patch is a potential fix to existing behavior.

The rest of the patch is to remove these flags whenever `-dynamiclib` is
removed, because these flags only make sense with it. Unfortunately, this
removal happens in two places, due to pre-existing code duplication -- this
patch just changes both places.

Minor behaviour change, in case it has some unintended sideffects:
`-single_module` flag was only removed if `-dynamiclib` was present; after this
patch, they are both removed separately if present.

I only tested this patch against the *standalone* release of libtdb v1.13.6
from here: https://www.samba.org/ftp/tdb/. I built in the context of the brew
formula for tdb that I am about to submit to Homebrew.

Also, note that that I had to `./configure` with `--disable-rpath
--disable-rpath-install --disable-rpath-private-install`, otherwise
applications do link against the resulting libtdb.dynlib but fail at runtime,
because they are looking for libtdb.inst.dynlib instead of libtdb.dynlib and
not finding it.

Signed-off-by: Alexei Colin <ac@alexeicolin.com>