### PR TITLE
Relax GPGME version check

### DIFF
--- a/source4/dsdb/samdb/ldb_modules/password_hash.c
+++ b/source4/dsdb/samdb/ldb_modules/password_hash.c
@@ -51,6 +51,7 @@
 #ifdef ENABLE_GPGME
 #undef class
 #include <gpgme.h>
+#define MINIMUM_GPGME_VERSION "1.2.0"
 #endif
 
 /* If we have decided there is a reason to work on this request, then
@@ -4805,13 +4806,13 @@ int ldb_password_hash_module_init(const char *version)
 	 * if none is active already. See:
 	 * https://www.gnupg.org/documentation/manuals/gpgme/Signal-Handling.html#Signal-Handling
 	 */
-	gversion = gpgme_check_version(GPGME_VERSION);
+	gversion = gpgme_check_version(MINIMUM_GPGME_VERSION);
 	if (gversion == NULL) {
 		fprintf(stderr, "%s() in %s version[%s]: "
 			"gpgme_check_version(%s) not available, "
 			"gpgme_check_version(NULL) => '%s'\n",
 			__func__, __FILE__, version,
-			GPGME_VERSION, gpgme_check_version(NULL));
+			MINIMUM_GPGME_VERSION, gpgme_check_version(NULL));
 		return LDB_ERR_UNAVAILABLE;
 	}
 #endif /* ENABLE_GPGME */


### PR DESCRIPTION
The current method require at least the same version as during the build. This is not needed.

Used symbols indicate the minimum is 1.2.0

Bug-Debian: http://bugs.debian.org/886333
Signed-off-by: Mathieu Parent <math.parent@gmail.com>