### PR TITLE
Improve amd64 detection on sunos

### DIFF
--- a/third_party/aesni-intel/wscript
+++ b/third_party/aesni-intel/wscript
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from waflib import Options, Utils
-from subprocess import Popen, PIPE
 
 def configure(conf):
     if Options.options.accel_aes.lower() != "intelaesni":
@@ -24,7 +23,7 @@ def configure(conf):
     linking check.
     ''' 
     if platform == "sunos":
-        arch = Popen(['isainfo'], stdout=PIPE).communicate()[0]
+        arch = Utils.cmd_output('isainfo').strip('\n')
         if "amd64" in arch:
             amd64 = True
     else:

--- a/third_party/aesni-intel/wscript
+++ b/third_party/aesni-intel/wscript
@@ -1,31 +1,59 @@
 #!/usr/bin/env python
-from waflib import Options
-from waflib import Utils
+from waflib import Options, Utils
+from subprocess import Popen, PIPE
 
 def configure(conf):
-    if Options.options.accel_aes.lower() == "intelaesni":
-        asm_flags = ('-Wp,-E,-lang-asm', '-xassembler-with-cpp')
-        for f in asm_flags:
-            if conf.CHECK_CFLAGS(f, ''):
-                conf.DEFINE('AESNI_INTEL_CFLAGS', f)
-                break
-        if conf.CONFIG_SET('AESNI_INTEL_CFLAGS'):
-            if conf.env['SYSTEM_UNAME_MACHINE'] in ('x86_64', 'amd64'):
-                print("Compiling with Intel AES instructions")
-                conf.DEFINE('HAVE_AESNI_INTEL', 1)
-            else:
-                raise Utils.WafError('--accel-aes=intelaesni selected and non x86_64 CPU')
-        else:
-            raise Utils.WafError('--aes-accel=intelaesni selected and compiler rejects ' + str(asm_flags))
+    if Options.options.accel_aes.lower() != "intelaesni":
+        return
+
+    asm_flags = ('-Wp,-E,-lang-asm', '-xassembler-with-cpp')
+    for f in asm_flags:
+        if conf.CHECK_CFLAGS(f, ''):
+            conf.DEFINE('AESNI_INTEL_CFLAGS', f)
+            break
+
+    if not conf.CONFIG_SET('AESNI_INTEL_CFLAGS'):
+        raise Utils.WafError('--accel-aes=intelaesni selected and compiler \
+                             rejects ' + str(asm_flags))
+
+    amd64 = False
+    platform = Utils.unversioned_sys_platform()
+    '''SunOS may not include x86_64 or amd64 in uname output. Instead,
+    isainfo can be used to determine architecture. SunOS also does not
+    support noexecstack option (to my knowledge) so we skip noexecstack
+    linking check.
+    ''' 
+    if platform == "sunos":
+        arch = Popen(['isainfo'], stdout=PIPE).communicate()[0]
+        if "amd64" in arch:
+            amd64 = True
+    else:
+        if conf.env['SYSTEM_UNAME_MACHINE'] in ('x86_64', 'amd64'):
+            amd64 = True
+
+    if amd64 and platform != "sunos":
         if not conf.CHECK_LDFLAGS('-Wl,-z,noexecstack'):
-            raise Utils.WafError('--accel-aes=intelaesni selected and linker rejects -z noexecstack')
+            raise Utils.WafError('--accel-aes=intelaesni selected and linker \
+                                rejects -z noexecstack')
+    if amd64:
+        print("Compiling with Intel AES instructions")
+        conf.DEFINE('HAVE_AESNI_INTEL', 1)
+    else:
+        raise Utils.WafError('--accel-aes=intelaesni selected and non \
+                             x86_64 CPU')
 
 def build(bld):
     if not bld.CONFIG_SET('HAVE_AESNI_INTEL'):
         return
 
-    bld.SAMBA_LIBRARY('aesni-intel',
-        source='aesni-intel_asm.c',
-        cflags=bld.CONFIG_GET('AESNI_INTEL_CFLAGS'),
-        ldflags='-Wl,-z,noexecstack',
-        private_library=True)
+    if Utils.unversioned_sys_platform() == 'sunos':
+        bld.SAMBA_LIBRARY('aesni-intel',
+                          source='aesni-intel_asm.c',
+                          cflags=bld.CONFIG_GET('AESNI_INTEL_CFLAGS'),
+                          private_library=True)
+    else:
+        bld.SAMBA_LIBRARY('aesni-intel',
+                          source='aesni-intel_asm.c',
+                          cflags=bld.CONFIG_GET('AESNI_INTEL_CFLAGS'),
+                          ldflags='-Wl,-z,noexecstack',
+                          private_library=True)


### PR DESCRIPTION
SunOS may not include x86_64 or amd64 in uname output. Instead, isainfo can be used to determine architecture. SunOS also does not support noexecstack option (to my knowledge) so we skip noexecstack linking check.

Signed-off-by: Adam Malleo <amalleo25@gmail.com>