### PR TITLE
Use canonical path for Perl

### DIFF
--- a/examples/misc/wall.perl
+++ b/examples/misc/wall.perl
@@ -1,4 +1,4 @@
-#! /usr/bin/env perl
+#!/usr/bin/perl
 # 
 #@(#) smb-wall.pl Description:
 #@(#) A perl script which allows you to announce whatever you choose to

--- a/pidl/pidl
+++ b/pidl/pidl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 
 ###################################################
 # package to parse IDL files and generate code for

--- a/script/show_testsuite_time
+++ b/script/show_testsuite_time
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 use Time::Local ('timegm');
 my $in = STDIN;
 use strict;

--- a/source3/script/findsmb.in
+++ b/source3/script/findsmb.in
@@ -1,4 +1,4 @@
-#!@PERL@
+#!/usr/bin/perl
 #
 # Prints info on all smb responding machines on a subnet.
 # This script needs to be run on a machine without nmbd running and be

--- a/source3/script/wscript_build
+++ b/source3/script/wscript_build
@@ -11,13 +11,10 @@ bld.SAMBA_SCRIPT('smbaddshare', pattern='smbaddshare', installdir='.')
 bld.SAMBA_SCRIPT('smbchangeshare', pattern='smbchangeshare', installdir='.')
 bld.SAMBA_SCRIPT('smbdeleteshare', pattern='smbdeleteshare', installdir='.')
 
-sed_expr1 = 's#@PERL@#/usr/bin/env perl#'
-sed_expr2 = 's#@BINDIR@#${BINDIR}#'
-
 bld.SAMBA_GENERATOR('findsmb-script',
                     source='findsmb.in',
                     target='findsmb',
-                    rule='sed -e "%s" -e "%s" ${SRC} > ${TGT}' % (sed_expr1, sed_expr2))
+                    rule='sed -e "s#@BINDIR@#${BINDIR}#" ${SRC} > ${TGT}')
 
 bld.INSTALL_FILES('${BINDIR}',
                   'findsmb',

--- a/source4/script/buildtree.pl
+++ b/source4/script/buildtree.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/env perl -w
+#!/usr/bin/perl -w
     eval 'exec /usr/bin/env perl -S $0 ${1+"$@"}'
         if 0; #$running_under_some_shell
 


### PR DESCRIPTION
Samba codebase mostly uses '#!/usr/bin/perl' as perl's shbang.

This ensures uniform Perl modules availibility.

Signed-off-by: Mathieu Parent <math.parent@gmail.com>