### PR TITLE
Don't use sysconf(_SC_NGROUPS_MAX) MacOS

### DIFF
--- a/source3/lib/system.c
+++ b/source3/lib/system.c
@@ -776,7 +776,18 @@ void sys_srandom(unsigned int seed)
 
 int groups_max(void)
 {
-#if defined(SYSCONF_SC_NGROUPS_MAX)
+#if defined(DARWINOS)
+	/*
+	 * On MacOS sysconf(_SC_NGROUPS_MAX) returns 16
+	 * due to MacOS's group nesting. However, getgroups()
+	 * will return a flat list and return -1 if that flat list
+	 * exceeds the limit of 16 (which seems to be the case for
+	 * the root user on any 10.14 system). Since the sysconf()
+	 * constant is not related to what getgroups() uses we
+	 * return a fixed constant here.
+	 */
+	return 128;
+#elif defined(SYSCONF_SC_NGROUPS_MAX)
 	int ret = sysconf(_SC_NGROUPS_MAX);
 	return (ret == -1) ? NGROUPS_MAX : ret;
 #else


### PR DESCRIPTION
On MacOS sysconf(_SC_NGROUPS_MAX) always returns 16. However, this is not
the value used by getgroups(2). MacOS uses nested groups but getgroups(2)
will return the flattened list which can easily exceed 16 groups. In my
testing getgroups() already returns 16 groups on a freshly installed
system. And on a 10.14 system the root user is in more than 16 groups by
default which makes it impossible to run smbd without this change.

See https://bugzilla.samba.org/show_bug.cgi?id=8773