### PR TITLE
Always use /usr/bin/env to call Perl

### DIFF
--- a/ctdb/utils/nagios/check_ctdb
+++ b/ctdb/utils/nagios/check_ctdb
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # Nagios plugin to monitor CTDB (Clustered Trivial Database)
 #
 # License: GPL

--- a/docs-xml/scripts/indent-smb.conf.pl
+++ b/docs-xml/scripts/indent-smb.conf.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 while(<STDIN>) {
 	if(/^$/) { }

--- a/examples/LDAP/ol-schema-migrate.pl
+++ b/examples/LDAP/ol-schema-migrate.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 #
 # Convert OpenLDAP schema files into Fedora DS format with RFC2252 compliant printing
 #

--- a/examples/logon/genlogon/genlogon.pl
+++ b/examples/logon/genlogon/genlogon.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # genlogon.pl
 #

--- a/examples/logon/mklogon/mklogon.pl
+++ b/examples/logon/mklogon/mklogon.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 # 05/01/2005 - 18:07:10
 #

--- a/examples/misc/adssearch.pl
+++ b/examples/misc/adssearch.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # 
 # adssearch.pl 	- query an Active Directory server and
 #		  display objects in a human readable format

--- a/examples/misc/check_multiple_LDAP_entries.pl
+++ b/examples/misc/check_multiple_LDAP_entries.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # Guenther Deschner <gd@samba.org>
 #
 # check for multiple LDAP entries

--- a/examples/misc/cldap.pl
+++ b/examples/misc/cldap.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 # Copyright (C) Guenther Deschner <gd@samba.org> 2006
 

--- a/examples/misc/wall.perl
+++ b/examples/misc/wall.perl
@@ -1,4 +1,4 @@
-#! /usr/bin/env perl
+#!/usr/bin/env perl
 # 
 #@(#) smb-wall.pl Description:
 #@(#) A perl script which allows you to announce whatever you choose to

--- a/examples/printer-accounting/acct-sum
+++ b/examples/printer-accounting/acct-sum
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 while (<>) {
         ($date, $user, $machine, $size, $pages) = split(' ');

--- a/examples/printer-accounting/hp5-redir
+++ b/examples/printer-accounting/hp5-redir
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # 0 == stdin  == docuement
 # 1 == stdout == printer

--- a/examples/printer-accounting/lp-acct
+++ b/examples/printer-accounting/lp-acct
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # 0 == stdin  == docuement
 # 1 == stdout == printer

--- a/examples/scripts/eventlog/parselog.pl
+++ b/examples/scripts/eventlog/parselog.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 ######################################################################
 ##
 ##  Simple parselog script for Samba

--- a/examples/scripts/printing/cups/smbaddprinter.pl
+++ b/examples/scripts/printing/cups/smbaddprinter.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 ##   Add printer script for samba, APW, and cups
 ##   Copyright (C) Jeff Hardy <hardyjm@potsdam.edu> 2004
 ##

--- a/examples/scripts/printing/cups/smbdelprinter.pl
+++ b/examples/scripts/printing/cups/smbdelprinter.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 ##   Delete printer script for samba, APW, and cups
 ##   Copyright (C) Gerald (Jerry) Carter <jerry@samba.rog>    2004
 ##

--- a/examples/scripts/users_and_groups/adduserstogroups.pl
+++ b/examples/scripts/users_and_groups/adduserstogroups.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 #
 # adduserstogroups.pl

--- a/examples/scripts/users_and_groups/createdomobj.pl
+++ b/examples/scripts/users_and_groups/createdomobj.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 #
 # createdomobj.pl

--- a/librpc/tables.pl
+++ b/librpc/tables.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 ###################################################
 # package to produce a table of all idl parsers

--- a/pidl/tests/cutil.pl
+++ b/pidl/tests/cutil.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/dump.pl
+++ b/pidl/tests/dump.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/header.pl
+++ b/pidl/tests/header.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/ndr.pl
+++ b/pidl/tests/ndr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/ndr_align.pl
+++ b/pidl/tests/ndr_align.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # NDR alignment tests
 # (C) 2005 Jelmer Vernooij. Published under the GNU GPL
 use strict;

--- a/pidl/tests/ndr_alloc.pl
+++ b/pidl/tests/ndr_alloc.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # NDR allocation tests
 # (C) 2005 Jelmer Vernooij. Published under the GNU GPL
 use strict;

--- a/pidl/tests/ndr_array.pl
+++ b/pidl/tests/ndr_array.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Array testing
 # (C) 2005 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License

--- a/pidl/tests/ndr_compat.pl
+++ b/pidl/tests/ndr_compat.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/ndr_deprecations.pl
+++ b/pidl/tests/ndr_deprecations.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/ndr_fullptr.pl
+++ b/pidl/tests/ndr_fullptr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Simple tests for unique pointers
 # (C) 2006 Jelmer Vernooij <jelmer@samba.org>.
 # Published under the GNU General Public License.

--- a/pidl/tests/ndr_refptr.pl
+++ b/pidl/tests/ndr_refptr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Simple tests for pidl's handling of ref pointers, based
 # on tridge's ref_notes.txt
 # (C) 2005 Jelmer Vernooij <jelmer@samba.org>.

--- a/pidl/tests/ndr_represent.pl
+++ b/pidl/tests/ndr_represent.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # NDR represent_as() / transmit_as() tests
 # (C) 2006 Jelmer Vernooij. Published under the GNU GPL
 use strict;

--- a/pidl/tests/ndr_simple.pl
+++ b/pidl/tests/ndr_simple.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Some simple tests for pidl
 # (C) 2005 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License

--- a/pidl/tests/ndr_string.pl
+++ b/pidl/tests/ndr_string.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # String tests for pidl
 # (C) 2005 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License

--- a/pidl/tests/ndr_tagtype.pl
+++ b/pidl/tests/ndr_tagtype.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Support for tagged types
 # (C) 2005 Jelmer Vernooij. Published under the GNU GPL
 use strict;

--- a/pidl/tests/parse_idl.pl
+++ b/pidl/tests/parse_idl.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Some simple tests for pidls parsing routines
 # (C) 2005 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License

--- a/pidl/tests/samba-ndr.pl
+++ b/pidl/tests/samba-ndr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/samba3-cli.pl
+++ b/pidl/tests/samba3-cli.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/samba3-srv.pl
+++ b/pidl/tests/samba3-srv.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2008 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/tdr.pl
+++ b/pidl/tests/tdr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/test_util.pl
+++ b/pidl/tests/test_util.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/typelist.pl
+++ b/pidl/tests/typelist.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/util.pl
+++ b/pidl/tests/util.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 use strict;

--- a/pidl/tests/wireshark-conf.pl
+++ b/pidl/tests/wireshark-conf.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 # test parsing wireshark conformance files

--- a/pidl/tests/wireshark-ndr.pl
+++ b/pidl/tests/wireshark-ndr.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # (C) 2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU General Public License
 # test parsing wireshark conformance files

--- a/script/configure_check_unused.pl
+++ b/script/configure_check_unused.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Script that finds macros in a configure script that are not 
 # used in a set of C files.
 # Copyright Jelmer Vernooij <jelmer@samba.org>, GPL

--- a/script/findstatic.pl
+++ b/script/findstatic.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # find a list of fns and variables in the code that could be static
 # usually called with something like this:
 #    findstatic.pl `find . -name "*.o"`

--- a/script/traffic_summary.pl
+++ b/script/traffic_summary.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 #
 # Summarise tshark pdml output into a form suitable for the load test tool
 #

--- a/selftest/SocketWrapper.pm
+++ b/selftest/SocketWrapper.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Bootstrap Samba and run a number of tests against it.
 # Copyright (C) 2005-2007 Jelmer Vernooij <jelmer@samba.org>
 

--- a/selftest/selftest.pl
+++ b/selftest/selftest.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Bootstrap Samba and run a number of tests against it.
 # Copyright (C) 2005-2010 Jelmer Vernooij <jelmer@samba.org>
 # Copyright (C) 2007-2009 Stefan Metzmacher <metze@samba.org>

--- a/selftest/target/Samba.pm
+++ b/selftest/target/Samba.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Bootstrap Samba and run a number of tests against it.
 # Copyright (C) 2005-2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU GPL, v3 or later.

--- a/selftest/target/Samba3.pm
+++ b/selftest/target/Samba3.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Bootstrap Samba and run a number of tests against it.
 # Copyright (C) 2005-2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU GPL, v3 or later.

--- a/selftest/target/Samba4.pm
+++ b/selftest/target/Samba4.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Bootstrap Samba and run a number of tests against it.
 # Copyright (C) 2005-2007 Jelmer Vernooij <jelmer@samba.org>
 # Published under the GNU GPL, v3 or later.

--- a/source3/script/count_80_col.pl
+++ b/source3/script/count_80_col.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 open( INFILE, "$ARGV[0]" ) || die $@;
 

--- a/source3/script/findsmb.in
+++ b/source3/script/findsmb.in
@@ -1,4 +1,4 @@
-#!@PERL@
+#!/usr/bin/env perl
 #
 # Prints info on all smb responding machines on a subnet.
 # This script needs to be run on a machine without nmbd running and be

--- a/source3/script/fix_bool.pl
+++ b/source3/script/fix_bool.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 open(INFILE, "$ARGV[0]") || die $@;
 open(OUTFILE, ">$ARGV[0].new") || die $@;

--- a/source3/script/scancvslog.pl
+++ b/source3/script/scancvslog.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require"timelocal.pl";
 
 #

--- a/source3/script/strip_trail_ws.pl
+++ b/source3/script/strip_trail_ws.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 open( INFILE, "$ARGV[0]" ) || die $@;
 open( OUTFILE, ">$ARGV[0].new" ) || die $@;

--- a/source3/script/tests/fake_snap.pl
+++ b/source3/script/tests/fake_snap.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 use strict;
 

--- a/source3/script/tests/printing/modprinter.pl
+++ b/source3/script/tests/printing/modprinter.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 use strict;
 

--- a/source3/script/tests/test_smbclient_tarmode.pl
+++ b/source3/script/tests/test_smbclient_tarmode.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Unix SMB/CIFS implementation.
 # Test suite for the tar backup mode of smbclient.

--- a/source3/script/wscript_build
+++ b/source3/script/wscript_build
@@ -11,13 +11,10 @@ bld.SAMBA_SCRIPT('smbaddshare', pattern='smbaddshare', installdir='.')
 bld.SAMBA_SCRIPT('smbchangeshare', pattern='smbchangeshare', installdir='.')
 bld.SAMBA_SCRIPT('smbdeleteshare', pattern='smbdeleteshare', installdir='.')
 
-sed_expr1 = 's#@PERL@#/usr/bin/env perl#'
-sed_expr2 = 's#@BINDIR@#${BINDIR}#'
-
 bld.SAMBA_GENERATOR('findsmb-script',
                     source='findsmb.in',
                     target='findsmb',
-                    rule='sed -e "%s" -e "%s" ${SRC} > ${TGT}' % (sed_expr1, sed_expr2))
+                    rule='sed -e "s#@BINDIR@#${BINDIR}#" ${SRC} > ${TGT}')
 
 bld.INSTALL_FILES('${BINDIR}',
                   'findsmb',

--- a/source4/build/pasn1/pasn1.pl
+++ b/source4/build/pasn1/pasn1.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 ###################################################
 # package to parse ASN.1 files and generate code for

--- a/source4/script/buildtree.pl
+++ b/source4/script/buildtree.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/env perl -w
+#!/usr/bin/env perl -w
     eval 'exec /usr/bin/env perl -S $0 ${1+"$@"}'
         if 0; #$running_under_some_shell
 

--- a/source4/script/minimal_includes.pl
+++ b/source4/script/minimal_includes.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # find a list of #include lines in C code that might not be needed
 # usually called with something like this:
 #    minimal_includes.pl `find . -name "*.c"`

--- a/source4/script/mkproto.pl
+++ b/source4/script/mkproto.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Simple script for generating prototypes for C functions
 # Written by Jelmer Vernooij
 # based on the original mkproto.sh by Andrew Tridgell

--- a/source4/script/update-proto.pl
+++ b/source4/script/update-proto.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Simple script for updating the prototypes in a C header file
 #
 # Copyright (C) 2006 Jelmer Vernooij <jelmer@samba.org>

--- a/source4/scripting/bin/nsupdate-gss
+++ b/source4/scripting/bin/nsupdate-gss
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # update a win2000 DNS server using gss-tsig 
 # tridge@samba.org, October 2002
 

--- a/source4/selftest/win/VMHost.pm
+++ b/source4/selftest/win/VMHost.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 # A perl object to provide a simple, unified method of handling some
 # VMware Server VM management functions using the perl and VIX API's.

--- a/source4/selftest/win/vm_get_ip.pl
+++ b/source4/selftest/win/vm_get_ip.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 # A perl script to connect to a VMware server and get the IP address of a VM.
 # Copyright Brad Henry <brad@samba.org> 2006

--- a/source4/selftest/win/vm_load_snapshot.pl
+++ b/source4/selftest/win/vm_load_snapshot.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 # A perl script to connect to a VMware server and revert a VM snapshot.
 # Copyright Brad Henry <brad@samba.org> 2006

--- a/third_party/nss_wrapper/nss_wrapper.pl
+++ b/third_party/nss_wrapper/nss_wrapper.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 
 use strict;


### PR DESCRIPTION
... to support systems where perl is not installed in /usr/bin/.