### PR TITLE
Fix compatibility issues with the timespec struct

### DIFF
--- a/source3/include/libsmbclient.h
+++ b/source3/include/libsmbclient.h
@@ -78,6 +78,7 @@ extern "C" {
 #include <sys/statvfs.h>
 #include <stdint.h>
 #include <fcntl.h>
+#include <time.h>
 #include <utime.h>
 
 #define SMBC_BASE_FD        10000 /* smallest file descriptor returned */


### PR DESCRIPTION
I'm compiling `ffmpeg` with `--enable-libsmbclient`. During the configuration phase I'm getting:
```
./ffbuild/config.log:/usr/include/samba-4.0/libsmbclient.h:158:18: error: field 'btime_ts' has incomplete type
./ffbuild/config.log:/usr/include/samba-4.0/libsmbclient.h:162:18: error: field 'mtime_ts' has incomplete type
./ffbuild/config.log:/usr/include/samba-4.0/libsmbclient.h:166:18: error: field 'atime_ts' has incomplete type
./ffbuild/config.log:/usr/include/samba-4.0/libsmbclient.h:170:18: error: field 'ctime_ts' has incomplete type
```

The problem appears to be that the `timespec` struct is not defined. Including `time.h` solves the issue. It can be reproduced in 4.9.1, but not in 4.8.

In a somewhat related note - libsmbclient.h currently cannot be used with `--std=c99` because of the dependency on `timespec`.