### PR TITLE
Fix bind DLZ module to prevent zone transfers for everyone

### DIFF
--- a/docs-xml/smbdotconf/domain/dnszonetransferclients.xml
+++ b/docs-xml/smbdotconf/domain/dnszonetransferclients.xml
@@ -1,0 +1,19 @@
+<samba:parameter name="dns zone transfer clients"
+                 context="G"
+                 type="cmdlist"
+                 xmlns:samba="http://www.samba.org/samba/DTD/samba-doc">
+<description>
+	<para>This option specifies the list IPs authorized to ask for dns zone
+	    transfer.
+	</para>
+
+	<para>The content is a comma-separated list of IP addresses.
+	</para>
+
+	<para>Default is "none", meaning no transfer will be authorized.
+	</para>
+</description>
+
+<value type="default">none</value>
+<value type="example">192.168.0.1</value>
+</samba:parameter>


### PR DESCRIPTION
See https://bugzilla.samba.org/show_bug.cgi?id=9634 for bug reference and suggested changes.

- add an option to smb.conf to list authorized zone transfer clients
- implement restriction in dlz module to allow transfers only to selected IPs