### PR TITLE
Add --authentication-file option support to "net"

### DIFF
--- a/docs-xml/manpages/net.8.xml
+++ b/docs-xml/manpages/net.8.xml
@@ -26,6 +26,7 @@
 		<arg choice="opt">-w|--workgroup workgroup</arg>
 		<arg choice="opt">-W|--myworkgroup myworkgroup</arg>
 		<arg choice="opt">-U|--user user</arg>
+		<arg choice="opt">-A|--authentication-file authfile</arg>
 		<arg choice="opt">-I|--ipaddress ip-address</arg>
 		<arg choice="opt">-p|--port port</arg>
 		<arg choice="opt">-n myname</arg>

--- a/source3/script/tests/test_net_rpc_join_creds.sh
+++ b/source3/script/tests/test_net_rpc_join_creds.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+if [ $# -lt 5 ]; then
+cat <<EOF
+Usage: test_net_rpc_join_creds.sh  DOMAIN USERNAME PASSWORD SERVER PREFIX
+EOF
+exit 1;
+fi
+
+DOMAIN="$1"
+USERNAME="$2"
+PASSWORD="$3"
+SERVER="$4"
+PREFIX="$5"
+shift 5
+ADDARGS="$*"
+
+incdir=`dirname $0`/../../../testprogs/blackbox
+. $incdir/subunit.sh
+mkdir -p $PREFIX/private
+# Test using a credentials file.
+credsfile=$PREFIX/creds.$$
+printf '%s\n' "username=$USERNAME" "password=$PASSWORD" "domain=$DOMAIN" > "$credsfile"
+testit "net_rpc_join_creds" $VALGRIND $BINDIR/net rpc join -S $SERVER --option=netbiosname=netrpcjointest --option=domainlogons=yes --option=privatedir=$PREFIX/private -A"$credsfile" $ADDARGS || failed=`expr $failed + 1`
+testit "net_rpc_testjoin_creds" $VALGRIND $BINDIR/net rpc testjoin -S $SERVER --option=netbiosname=netrpcjointest --option=domainlogons=yes --option=privatedir=$PREFIX/private $ADDARGS || failed=`expr $failed + 1`
+testit "net_rpc_changetrustpw_creds" $VALGRIND $BINDIR/net rpc changetrustpw -S $SERVER --option=netbiosname=netrpcjointest --option=domainlogons=yes --option=privatedir=$PREFIX/private $ADDARGS || failed=`expr $failed + 1`
+testit "net_rpc_testjoin2_creds" $VALGRIND $BINDIR/net rpc testjoin -S $SERVER --option=netbiosname=netrpcjointest --option=domainlogons=yes --option=privatedir=$PREFIX/private $ADDARGS || failed=`expr $failed + 1`
+rm -f $credsfile
+
+testok $0 $failed

--- a/source3/selftest/tests.py
+++ b/source3/selftest/tests.py
@@ -717,6 +717,10 @@ plantestsuite("samba3.blackbox.net_rpc_oldjoin", "nt4_dc:local",
               [os.path.join(samba3srcdir, "script/tests/test_net_rpc_oldjoin.sh"),
                "$SERVER", "$PREFIX/net_rpc_oldjoin",
                "$SMB_CONF_PATH"])
+plantestsuite("samba3.blackbox.net_rpc_join_creds", "nt4_dc",
+              [os.path.join(samba3srcdir, "script/tests/test_net_rpc_join_creds.sh"),
+               "$DOMAIN", "$USERNAME", "$PASSWORD", "$SERVER", "$PREFIX/net_rpc_join_creds",
+               configuration])
 
 plantestsuite("samba3.blackbox.rpcclient_srvsvc", "simpleserver",
               [os.path.join(samba3srcdir, "script/tests/test_rpcclientsrvsvc.sh"),


### PR DESCRIPTION
This patch extends net to support the same `-A authfile`/`--authentication-file authfile` option that most of the other tools already do.