### PR TITLE
Update nfs-ganesha-callout

### DIFF
--- a/ctdb/doc/examples/nfs-ganesha-callout
+++ b/ctdb/doc/examples/nfs-ganesha-callout
@@ -297,7 +297,7 @@ nfs_startup ()
 
 	basic_start "nfs"
 	_f="${procfs}/sys/net/ipv4/tcp_tw_recycle"
-	if [ "$_f" ] ; then
+	if [ -f "$_f" ] ; then
 		echo 1 >"$_f"
 	fi
 }


### PR DESCRIPTION
On debian buster, this variable doesn't exist anymore. Look at this PR as a reference:
https://github.com/gluster/storhaug/pull/30

## Samba is moving to GitLab
The samba project is moving to GitLab, please consider opening a merge request there instead.
Instructions for setting up can be found at: https://wiki.samba.org/index.php/Samba_CI_on_gitlab
The GitLab repository can be found here: https://gitlab.com/samba-team/samba
