### PR TITLE
Fix/dns name equal

### DIFF
--- a/python/samba/dnsserver.py
+++ b/python/samba/dnsserver.py
@@ -308,7 +308,7 @@ def recbuf_from_string(*args, **kwargs):
     return buf
 
 
-def dns_name_equal(n1, n2):
+def samba_dns_name_equal(n1, n2):
     """Match dns name (of type DNS_RPC_NAME)"""
     return n1.str.rstrip('.').lower() == n2.str.rstrip('.').lower()
 
@@ -363,23 +363,23 @@ def dns_record_match(dns_conn, server, zone, name, record_type, data):
             if ipv6_normalise(rec.data) == ipv6_normalise(urec.data):
                 found = True
         elif record_type == dnsp.DNS_TYPE_PTR:
-            if dns_name_equal(rec.data, urec.data):
+            if samba_dns_name_equal(rec.data, urec.data):
                 found = True
         elif record_type == dnsp.DNS_TYPE_CNAME:
-            if dns_name_equal(rec.data, urec.data):
+            if samba_dns_name_equal(rec.data, urec.data):
                 found = True
         elif record_type == dnsp.DNS_TYPE_NS:
-            if dns_name_equal(rec.data, urec.data):
+            if samba_dns_name_equal(rec.data, urec.data):
                 found = True
         elif record_type == dnsp.DNS_TYPE_MX:
-            if dns_name_equal(rec.data.nameExchange, urec.data.nameExchange) and \
+            if samba_dns_name_equal(rec.data.nameExchange, urec.data.nameExchange) and \
                rec.data.wPreference == urec.data.wPreference:
                 found = True
         elif record_type == dnsp.DNS_TYPE_SRV:
             if rec.data.wPriority == urec.data.wPriority and \
                rec.data.wWeight == urec.data.wWeight and \
                rec.data.wPort == urec.data.wPort and \
-               dns_name_equal(rec.data.nameTarget, urec.data.nameTarget):
+               samba_dns_name_equal(rec.data.nameTarget, urec.data.nameTarget):
                 found = True
         elif record_type == dnsp.DNS_TYPE_SOA:
             if rec.data.dwSerialNo == urec.data.dwSerialNo and \
@@ -387,9 +387,9 @@ def dns_record_match(dns_conn, server, zone, name, record_type, data):
                rec.data.dwRetry == urec.data.dwRetry and \
                rec.data.dwExpire == urec.data.dwExpire and \
                rec.data.dwMinimumTtl == urec.data.dwMinimumTtl and \
-               dns_name_equal(rec.data.NamePrimaryServer,
+               samba_dns_name_equal(rec.data.NamePrimaryServer,
                               urec.data.NamePrimaryServer) and \
-               dns_name_equal(rec.data.ZoneAdministratorEmail,
+               samba_dns_name_equal(rec.data.ZoneAdministratorEmail,
                               urec.data.ZoneAdministratorEmail):
                 found = True
         elif record_type == dnsp.DNS_TYPE_TXT:

--- a/source4/dns_server/dns_crypto.c
+++ b/source4/dns_server/dns_crypto.c
@@ -81,7 +81,7 @@ struct dns_server_tkey *dns_find_tkey(struct dns_server_tkey_store *store,
 		if (tmp_key == NULL) {
 			continue;
 		}
-		if (dns_name_equal(name, tmp_key->name)) {
+		if (samba_dns_name_equal(name, tmp_key->name)) {
 			tkey = tmp_key;
 			break;
 		}

--- a/source4/dns_server/dns_update.c
+++ b/source4/dns_server/dns_update.c
@@ -593,7 +593,7 @@ static WERROR handle_one_update(struct dns_server *dns,
 		 * work out if the node as a whole needs tombstoning.
 		 */
 		if (update->rr_type == DNS_QTYPE_ALL) {
-			if (dns_name_equal(update->name, zone->name)) {
+			if (samba_dns_name_equal(update->name, zone->name)) {
 				for (i = first; i < rcount; i++) {
 
 					if (recs[i].wType == DNS_TYPE_SOA) {
@@ -617,7 +617,7 @@ static WERROR handle_one_update(struct dns_server *dns,
 				}
 			}
 
-		} else if (dns_name_equal(update->name, zone->name)) {
+		} else if (samba_dns_name_equal(update->name, zone->name)) {
 
 			if (update->rr_type == DNS_QTYPE_SOA) {
 				return WERR_OK;

--- a/source4/dns_server/dnsserver_common.c
+++ b/source4/dns_server/dnsserver_common.c
@@ -1331,7 +1331,7 @@ bool dns_record_match(struct dnsp_DnssrvRpcRecord *rec1,
 		return memcmp(&rec1_in_addr6, &rec2_in_addr6, sizeof(rec1_in_addr6)) == 0;
 	}
 	case DNS_TYPE_CNAME:
-		return dns_name_equal(rec1->data.cname, rec2->data.cname);
+		return samba_dns_name_equal(rec1->data.cname, rec2->data.cname);
 	case DNS_TYPE_TXT:
 		if (rec1->data.txt.count != rec2->data.txt.count) {
 			return false;
@@ -1343,23 +1343,23 @@ bool dns_record_match(struct dnsp_DnssrvRpcRecord *rec1,
 		}
 		return true;
 	case DNS_TYPE_PTR:
-		return dns_name_equal(rec1->data.ptr, rec2->data.ptr);
+		return samba_dns_name_equal(rec1->data.ptr, rec2->data.ptr);
 	case DNS_TYPE_NS:
-		return dns_name_equal(rec1->data.ns, rec2->data.ns);
+		return samba_dns_name_equal(rec1->data.ns, rec2->data.ns);
 
 	case DNS_TYPE_SRV:
 		return rec1->data.srv.wPriority == rec2->data.srv.wPriority &&
 			rec1->data.srv.wWeight  == rec2->data.srv.wWeight &&
 			rec1->data.srv.wPort    == rec2->data.srv.wPort &&
-			dns_name_equal(rec1->data.srv.nameTarget, rec2->data.srv.nameTarget);
+			samba_dns_name_equal(rec1->data.srv.nameTarget, rec2->data.srv.nameTarget);
 
 	case DNS_TYPE_MX:
 		return rec1->data.mx.wPriority == rec2->data.mx.wPriority &&
-			dns_name_equal(rec1->data.mx.nameTarget, rec2->data.mx.nameTarget);
+			samba_dns_name_equal(rec1->data.mx.nameTarget, rec2->data.mx.nameTarget);
 
 	case DNS_TYPE_SOA:
-		return dns_name_equal(rec1->data.soa.mname, rec2->data.soa.mname) &&
-			dns_name_equal(rec1->data.soa.rname, rec2->data.soa.rname) &&
+		return samba_dns_name_equal(rec1->data.soa.mname, rec2->data.soa.mname) &&
+			samba_dns_name_equal(rec1->data.soa.rname, rec2->data.soa.rname) &&
 			rec1->data.soa.serial == rec2->data.soa.serial &&
 			rec1->data.soa.refresh == rec2->data.soa.refresh &&
 			rec1->data.soa.retry == rec2->data.soa.retry &&
@@ -1485,7 +1485,7 @@ exit:
 /*
   see if two DNS names are the same
  */
-bool dns_name_equal(const char *name1, const char *name2)
+bool samba_dns_name_equal(const char *name1, const char *name2)
 {
 	size_t len1 = strlen(name1);
 	size_t len2 = strlen(name2);

--- a/source4/dns_server/dnsserver_common.h
+++ b/source4/dns_server/dnsserver_common.h
@@ -76,7 +76,7 @@ WERROR dns_common_name2dn(struct ldb_context *samdb,
 			  TALLOC_CTX *mem_ctx,
 			  const char *name,
 			  struct ldb_dn **_dn);
-bool dns_name_equal(const char *name1, const char *name2);
+bool samba_dns_name_equal(const char *name1, const char *name2);
 
 bool dns_record_match(struct dnsp_DnssrvRpcRecord *rec1,
 		      struct dnsp_DnssrvRpcRecord *rec2);

--- a/source4/rpc_server/dnsserver/dnsutils.c
+++ b/source4/rpc_server/dnsserver/dnsutils.c
@@ -311,7 +311,7 @@ struct dnsserver_zone *dnsserver_find_zone(struct dnsserver_zone *zones, const c
 	struct dnsserver_zone *z = NULL;
 
 	for (z = zones; z; z = z->next) {
-		if (dns_name_equal(zone_name, z->name)) {
+		if (samba_dns_name_equal(zone_name, z->name)) {
 			break;
 		}
 	}


### PR DESCRIPTION
## 
Hello, I got `named` abort (core dump) when I use `samba_dnsupdate`, after restart it with command `named -g`, I got the following messages, after some debug work, I found samba calls `dns_name_equal` from __bind__,  instead of from name.c in its own project. After renamed it, it fixed.

### Environment
- platform: docker ubuntu 20.04
- Samba Version: 4.16.4
- BIND Version: 9.18.05
- git commit: 9618af1b66a (tag: samba 4.16.4)
- DC members number: 2

### coredump message 
```
1-Aug-2022 03:43:55.504 samba_dlz: starting transaction on zone bdc500.com                                                                                                                                        
11-Aug-2022 03:43:55.504 samba_dlz: allowing update of signer=BDTEST01\$\@BDC500.COM name=bdc500.com tcpaddr=192.168.3.134 type=NS key=3465244128.sig-bamboocloud.bdc500.com/160/0                                 
11-Aug-2022 03:43:55.504 client @0x7f75d4e29258 192.168.3.134#50864/key BDTEST01\$\@BDC500.COM: updating zone 'bdc500.com/NONE': adding an RR at 'bdc500.com' NS bdtest01.bdc500.com.                              
11-Aug-2022 03:43:55.504 name.c:664: REQUIRE(((name1) != ((void *)0) && ((const isc__magic_t *)(name1))->magic == ((('D') << 24 | ('N') << 16 | ('S') << 8 | ('n'))))) failed, back trace                          
11-Aug-2022 03:43:55.504 named(+0x252e7) [0x55950de952e7]                                                                                                                                                          
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(isc_assertion_failed+0x10) [0x7f75dbbb5190]                                                                                                          
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libdns-9.18.5.so(dns_name_equal+0x169) [0x7f75dba0e079]                                                                                                               
11-Aug-2022 03:43:55.504 /usr/local/samba/lib/private/libdnsserver-common-samba4.so(dns_record_match+0x1fa) [0x7f75d882dd3e]                                                                                 
11-Aug-2022 03:43:55.504 /usr/local/samba/lib/bind9/dlz_bind9_18.so(+0x8be3) [0x7f75d88b1be3]                                                                                                             
11-Aug-2022 03:43:55.504 /usr/local/sambalib/bind9/dlz_bind9_18.so(dlz_addrdataset+0x2dc) [0x7f75d88b1fc1]                                                                                               
11-Aug-2022 03:43:55.504 named(+0x23259) [0x55950de93259]                                                                                                                                                          
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libdns-9.18.5.so(+0x123940) [0x7f75dba9e940]                                                                                                                          
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libdns-9.18.5.so(+0x43ac5) [0x7f75db9beac5]                                                                                                                           
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libns-9.18.5.so(+0x32312) [0x7f75db961312]                                                                                                                            
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libns-9.18.5.so(+0x35297) [0x7f75db964297]                                                                                                                            
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(isc_task_run+0x2b4) [0x7f75dbbd31c4]                                                                                                                 
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(+0x1ed3d) [0x7f75dbb9bd3d]                                                                                                                           
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(+0x26252) [0x7f75dbba3252]                                                                                                                           
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(+0x268d3) [0x7f75dbba38d3]                                                                                                                           
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(+0x27287) [0x7f75dbba4287]                                                                                                                           
11-Aug-2022 03:43:55.504 /usr/local/lib/libuv.so.1(+0x125fa) [0x7f75db5a75fa]                                                                                                                                      
11-Aug-2022 03:43:55.504 /usr/local/lib/libuv.so.1(+0x30450) [0x7f75db5c5450]
11-Aug-2022 03:43:55.504 /usr/local/lib/libuv.so.1(uv_run+0xf6) [0x7f75db5a810e]
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(+0x26b7a) [0x7f75dbba3b7a]
11-Aug-2022 03:43:55.504 /usr/local/bind/lib/libisc-9.18.5.so(isc__trampoline_run+0x1a) [0x7f75dbbdb08a]
11-Aug-2022 03:43:55.504 /lib/x86_64-linux-gnu/libpthread.so.0(+0x8609) [0x7f75db55c609]
11-Aug-2022 03:43:55.504 /lib/x86_64-linux-gnu/libc.so.6(clone+0x43) [0x7f75db481133]
11-Aug-2022 05:48:35.570 exiting (due to assertion failure)                                           
Aborted (core dumped)
```
### gdb backtrace
```gdb
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50                                                                                                                                          
#1  0x00007fd626cee859 in __GI_abort () at abort.c:79                                                                                                                                                              
#2  0x000055730ff5393a in assertion_failed (file=<optimized out>, line=<optimized out>, type=<optimized out>,                                                                                                      
    cond=0x7fd62748e308 "((name1) != ((void *)0) && ((const isc__magic_t *)(name1))->magic == ((('D') << 24 | ('N') << 16 | ('S') << 8 | ('n'))))") at main.c:237                                                  
#3  0x00007fd62751f190 in isc_assertion_failed (file=file@entry=0x7fd62747713e "name.c", line=line@entry=664, type=type@entry=isc_assertiontype_require,                                                           
    cond=cond@entry=0x7fd62748e308 "((name1) != ((void *)0) && ((const isc__magic_t *)(name1))->magic == ((('D') << 24 | ('N') << 16 | ('S') << 8 | ('n'))))") at assertions.c:49                                  
#4  0x00007fd627378079 in dns_name_equal (name1=<optimized out>, name2=<optimized out>) at name.c:688                                                                                                              
#5  0x00007fd624197d3e in dns_record_match (rec1=0x7fd61c0309b0, rec2=0x7fd61c00d480) at ../../source4/dns_server/dnsserver_common.c:1348                                                                          
#6  0x00007fd62421bbe3 in b9_record_match (rec1=0x7fd61c0309b0, rec2=0x7fd61c00d480) at ../../source4/dns_server/dlz_bind9.c:1827                                                                                  
#7  0x00007fd62421bfc1 in dlz_addrdataset (name=0x7fd625a90470 "bdc500.com", rdatastr=0x7fd61c02c4f0 "bdc500.com.\t900\tIN\tNS\tbdtest01.bdc500.com.", dbdata=0x7fd62013fa00, version=0x7fd61c0128d0)              
    at ../../source4/dns_server/dlz_bind9.c:1943                                                                                                                                                                   
#8  0x000055730ff5c259 in dlopen_dlz_addrdataset (name=name@entry=0x7fd625a90470 "bdc500.com", rdatastr=rdatastr@entry=0x7fd61c02c4f0 "bdc500.com.\t900\tIN\tNS\tbdtest01.bdc500.com.",                            
    driverarg=<optimized out>, dbdata=0x7fd6200e8fb0, version=version@entry=0x7fd61c0128d0) at dlz_dlopen_driver.c:461                                                                                             
#9  0x00007fd627408940 in modrdataset (db=0x7fd6208ef550, node=<optimized out>, version=0x7fd61c0128d0, rdataset=0x7fd625a90950, mod_function=0x55730ff5c220 <dlopen_dlz_addrdataset>, options=<optimized out>)    
    at sdlz.c:1101                                                                                                                                                                                                 
#10 0x00007fd627328ac5 in diff_apply (diff=diff@entry=0x7fd625a90f90, db=db@entry=0x7fd6208ef550, ver=ver@entry=0x7fd61c0128d0, warn=warn@entry=true) at diff.c:363                                                
#11 0x00007fd62732968e in dns_diff_apply (diff=diff@entry=0x7fd625a90f90, db=db@entry=0x7fd6208ef550, ver=ver@entry=0x7fd61c0128d0) at diff.c:460                                                                  
#12 0x00007fd6272cb312 in do_one_tuple (tuple=tuple@entry=0x7fd625a91190, db=db@entry=0x7fd6208ef550, ver=ver@entry=0x7fd61c0128d0, diff=diff@entry=0x7fd625a91100) at update.c:454                                
#13 0x00007fd6272ce297 in update_one_rr (rdata=0x7fd625a911d0, ttl=<optimized out>, name=<optimized out>, op=DNS_DIFFOP_ADD, diff=0x7fd625a91100, ver=0x7fd61c0128d0, db=0x7fd6208ef550) at update.c:505           
#14 update_action (task=<optimized out>, event=<optimized out>) at update.c:3271                                                                                                                                   
#15 0x00007fd62753d1c4 in task_run (task=0x557310ce4f40) at task.c:821                                                                                                                                             
#16 isc_task_run (task=0x557310ce4f40) at task.c:901                                                                                                                                                               
#17 0x00007fd627505d3d in isc__nm_async_task (ev0=ev0@entry=0x7fd62008fe90, worker=0x557310c5fab0) at netmgr/netmgr.c:832                                                                                          
#18 0x00007fd62750d252 in process_netievent (worker=worker@entry=0x557310c5fab0, ievent=0x7fd62008fe90) at netmgr/netmgr.c:904                                                                                     
#19 0x00007fd62750d8d3 in process_queue (worker=worker@entry=0x557310c5fab0, type=type@entry=NETIEVENT_TASK) at netmgr/netmgr.c:997                                                                                
#20 0x00007fd62750e287 in process_all_queues (worker=0x557310c5fab0) at netmgr/netmgr.c:780                                                                                                                        
#21 async_cb (handle=0x557310c5fe10) at netmgr/netmgr.c:780                                                                                                                                                        
#22 0x00007fd626f115fa in uv.async_io () from /usr/local/lib/libuv.so.1                                                                                                                                            
#23 0x00007fd626f2f450 in uv.io_poll () from /usr/local/lib/libuv.so.1                                                                                                                                             
--Type <RET> for more, q to quit, c to continue without paging--up                                                                                                                                                 
#24 0x00007fd626f1210e in uv_run () from /usr/local/lib/libuv.so.1                                                                                                                                                 
#25 0x00007fd62750db7a in nm_thread (worker0=0x557310c5fab0) at netmgr/netmgr.c:682                                                                                                                                
#26 0x00007fd62754508a in isc__trampoline_run (arg=0x557310c5a5b0) at trampoline.c:189                                                                                                                             
#27 0x00007fd626ec6609 in start_thread (arg=<optimized out>) at pthread_create.c:477                                                                                                                               
#28 0x00007fd626deb133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95  
```
