### PR TITLE
fix regression on smbc_getxattr and fix doc

### DIFF
--- a/source3/include/libsmbclient.h
+++ b/source3/include/libsmbclient.h
@@ -2419,7 +2419,7 @@ int smbc_getxattr(const char *url,
  *                  required to hold the attribute value will be returned,
  *                  but nothing will be placed into the value buffer.
  *
- * @return          0 on success, < 0 on error with errno set:
+ * @return          size on success, < 0 on error with errno set:
  *                  - EINVAL  The client library is not properly initialized
  *                            or one of the parameters is not of a correct
  *                            form

--- a/source3/libsmb/libsmb_xattr.c
+++ b/source3/libsmb/libsmb_xattr.c
@@ -2182,9 +2182,9 @@ SMBC_getxattr_ctx(SMBCCTX *context,
 		TALLOC_FREE(frame);
 		/*
 		 * static function cacl_get returns a value greater than zero
-		 * on success. Map this to zero meaning success.
+		 * which is needed buffer size needed when size_t is 0.
 		 */
-                return ret < 0 ? -1 : 0;
+                return ret;
         }
 
         /* Unsupported attribute name */


### PR DESCRIPTION
Regression introduce in 113536e0d735a5235f8be29d4fd1cfc8177930b1

This was a documentation issue
The return is the buffer size, as explained at another place

```
 * @param size      The size of the buffer pointed to by value.  This parameter
 *                  may also be zero, in which case the size of the buffer
 *                  required to hold the attribute value will be returned,
 *                  but nothing will be placed into the value buffer.
```

So this is mostly a revert of the change for https://bugzilla.samba.org/show_bug.cgi?id=14808
and fixing the documentation.

Needed in 4.16 and 4.17